### PR TITLE
add a command to find backlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     ],
     "commands": [
       {
+        "command": "vscodeMarkdownNotes.findBacklinks",
+        "title": "VS Code Markdown Notes: Find Backlinks"
+      },
+      {
         "command": "vscodeMarkdownNotes.newNote",
         "title": "VS Code Markdown Notes: New Note"
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -293,6 +293,13 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerDefinitionProvider(md, new MarkdownDefinitionProvider())
   );
 
+  let findBacklinksDisposable = vscode.commands.registerCommand('vscodeMarkdownNotes.findBacklinks', () => {
+    const filename = vscode.window.activeTextEditor?.document.fileName
+    if (filename !== undefined)
+      vscode.commands.executeCommand("workbench.action.findInFiles", { query: `[[${basename(filename)}]]`, triggerSearch: true, filesToInclude: '*.md, *.markdown' })
+  });
+  context.subscriptions.push(findBacklinksDisposable);
+
   let newNoteDisposable = vscode.commands.registerCommand('vscodeMarkdownNotes.newNote', newNote);
   context.subscriptions.push(newNoteDisposable);
 


### PR DESCRIPTION
Resolve in part #13 

It only set the query of the search panel to the name of the file. I think it is good enough, thanks to the cmd+click behaviour on search results (open to the side).
The association with the search editor [extension](https://marketplace.visualstudio.com/items?itemName=jakearl.search-editor-apply-changes) is also quite powerful.