### PR TITLE
calculate range for CompletionItem

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Backlinks"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,17 @@
 {
     "cSpell.words": [
-        "Backlinks"
+        "Backlinks",
+        "Devops",
+        "Suping",
+        "basenames",
+        "filepath",
+        "jumplist",
+        "notetaking",
+        "nvalt",
+        "prefill",
+        "vpackage",
+        "vpublish",
+        "vsce",
+        "vsix"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VS Code Markdown Notes
 
-Use `[[wiki-links]]` and `#tags` for fast-navigation between notes kept in in a VS Code workspace. Quickly create new notes from a Tilte Case Note Name.
+Use `[[wiki-links]]` and `#tags` for fast-navigation between notes kept in in a VS Code workspace. Quickly create new notes from a Title Case Note Name.
 
 There are many great note-taking applications ([Notational Velocity](http://notational.net/), [nvalt](https://brettterpstra.com/projects/nvalt/), [Bear](https://bear.app/), [FSNotes](https://fsnot.es/)), but few of them offer the extensibility of VS Code and the ability to use Vim bindings for editing notes.
 
@@ -28,7 +28,7 @@ You can bind this to a keyboard shortcut by adding to your `keybindings.json`:
 
 ```json
     {
-        "key": "al+shiftt+n",
+        "key": "al+shift+n",
         "command": "vscodeMarkdownNotes.newNote",
     },
 ```
@@ -66,15 +66,14 @@ Run `npm install` first.
 ### FAQ
 
 - "Autocomplete / Intellisense is not working - why?"
-    - Make sure that quick suggestions are enabled in Markdown. Put this in settings.json:
-    
-    ```
-    "[markdown]": {
-       "editor.quickSuggestions": true
-    } 
-    ```
+  - Make sure that quick suggestions are enabled in Markdown. Put this in settings.json:
+  ```
+  "[markdown]": {
+     "editor.quickSuggestions": true
+  }
+  ```
 - "New note is not working - why?"
-    - New Note works only when you are in a workspace. Look [here](https://stackoverflow.com/questions/44629890/what-is-a-workspace-in-visual-studio-code) for more information on workspaces in VS Code.
+  - New Note works only when you are in a workspace. Look [here](https://stackoverflow.com/questions/44629890/what-is-a-workspace-in-visual-studio-code) for more information on workspaces in VS Code.
 
 ### Known Issues
 
@@ -99,7 +98,7 @@ To create a new release,
 ```sh
 npm install
 # bump version number in package.json
-npm run vpackage # package the release, creates ,vsix
+npm run vpackage # package the release, creates vsix
 npm run vpublish # publish to store, see https://code.visualstudio.com/api/working-with-extensions/publishing-extension
 # Will prompt for Azure Devops Personal Access Token, get fresh one at:
 # https://dev.azure.com/andrewkortina/

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Run `npm install` first.
 ### FAQ
 
 - "Autocomplete / Intellisense is not working - why?"
-  - Make sure that quick suggestions are enabled in Markdown. Put this in settings.json:
+  - Quick suggestions are not enabled by default in Markdown, so you have to manually  `triggerSuggest` OR put this in settings.json:
   ```
   "[markdown]": {
      "editor.quickSuggestions": true
@@ -77,7 +77,6 @@ Run `npm install` first.
 
 ### Known Issues
 
-- Filename completion seems to be triggering when not in the `[[` context.
 - The `ctrl+o` VSCodeVim jumplist shortcut does not return you to the correct place after using "Go to Definition" (`ctrl+]`): https://github.com/VSCodeVim/Vim/issues/3277 (The VSCode `Go Back` command (`ctrl+-`) does work, however.)
 - This extension sets the `wordPattern` for 'markdown' in order to (1) enable proper completion of relative paths and (2) make it such that if you `cmd+shift+f` on a `#tag` the search will prefill with "#tag" and not just "tag":
   <br />`vscode.languages.setLanguageConfiguration('markdown', { wordPattern: /([\#\.\/\\\w_]+)/ });`
@@ -89,7 +88,6 @@ Run `npm install` first.
 - Provide better support for ignore patterns, eg, don't complete `file.md` if it is within `ignored_dir/`
 - Should we support filename without extension, eg, assume `[[file]]` is a reference to `file.md`?
 - Should we support links to headings? eg, `file.md#heading-text`?
-- Add syntax highlighting and search for `#tags`. See [also](https://stackoverflow.com/questions/60293955/is-cmdshiftf-in-vscode-supposed-to-respect-the-editor-wordseparators-setting)
 
 ### Development and Release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-markdown-notes",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -374,12 +374,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
       "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
-      "dev": true
-    },
-    "didyoumean": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
-      "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
       "dev": true
     },
     "doctrine": {
@@ -930,6 +924,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -956,16 +956,24 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
-        "entities": "~1.1.1",
+        "entities": "~2.0.0",
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+          "dev": true
+        }
       }
     },
     "mdurl": {
@@ -1242,9 +1250,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
     "safer-buffer": {
@@ -1509,9 +1517,9 @@
       "dev": true
     },
     "vsce": {
-      "version": "1.73.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.73.0.tgz",
-      "integrity": "sha512-6W37Ebbkj3uF3WhT+SCfRtsneRQEFcGvf/XYz+b6OAgDCj4gPurWyDVrqw/HLsbP1WflGIyUfVZ8t5M7kQp6Uw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.75.0.tgz",
+      "integrity": "sha512-qyAQTmolxKWc9bV1z0yBTSH4WEIWhDueBJMKB0GUFD6lM4MiaU1zJ9BtzekUORZu094YeNSKz0RmVVuxfqPq0g==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^7.2.0",
@@ -1519,10 +1527,10 @@
         "cheerio": "^1.0.0-rc.1",
         "commander": "^2.8.1",
         "denodeify": "^1.2.1",
-        "didyoumean": "^1.2.1",
         "glob": "^7.0.6",
-        "lodash": "^4.17.10",
-        "markdown-it": "^8.3.1",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "markdown-it": "^10.0.0",
         "mime": "^1.3.4",
         "minimatch": "^3.0.3",
         "osenv": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "@typescript-eslint/parser": "^2.28.0",
     "eslint": "^6.8.0",
     "typescript": "^3.5.1",
-    "vsce": "^1.73.0"
+    "vsce": "^1.75.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-markdown-notes",
   "displayName": "VS Code Markdown Notes",
-  "description": "Navigate notes with [[wiki-links]] and #tags (like Bear, Roam, etc). Use Peek Definition to preview linked notes. Quickly creatre new notes with a command.",
-  "version": "0.0.4",
+  "description": "Navigate notes with [[wiki-links]] and #tags (like Bear, Roam, etc). Use Peek Definition to preview linked notes. Quickly create new notes with a command.",
+  "version": "0.0.5",
   "publisher": "kortina",
   "repository": {
     "url": "https://github.com/kortina/vscode-markdown-notes.git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -318,7 +318,7 @@ const overrideMarkdownWordPattern = () => {
 export function activate(context: vscode.ExtensionContext) {
   // console.debug('vscode-markdown-notes.activate');
   const md = { scheme: 'file', language: 'markdown' };
-  overrideMarkdownWordPattern();
+  overrideMarkdownWordPattern(); // still nec to get ../ to trigger suggestions in `relativePaths` mode
 
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(md, new MarkdownFileCompletionItemProvider())

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,11 +133,11 @@ class MarkdownFileCompletionItemProvider implements CompletionItemProvider {
         break;
       case ContextWordType.Tag:
         // console.debug(`ContextWordType.Tag`);
-        // console.debug(
-        //   `contextWord.word: ${contextWord.word} TAG_WORD_SET: ${Array.from(
-        //     WorkspaceTagList.TAG_WORD_SET
-        //   )}`
-        // );
+        console.debug(
+          `contextWord.word: ${contextWord.word} TAG_WORD_SET: ${Array.from(
+            WorkspaceTagList.TAG_WORD_SET
+          )}`
+        );
         items = Array.from(WorkspaceTagList.TAG_WORD_SET).map((t) => {
           let kind = CompletionItemKind.File;
           let label = `${t}`; // cast to a string

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,7 +133,11 @@ class MarkdownFileCompletionItemProvider implements CompletionItemProvider {
         break;
       case ContextWordType.Tag:
         // console.debug(`ContextWordType.Tag`);
-        console.debug(`TAG_WORD_SET: ${Array.from(WorkspaceTagList.TAG_WORD_SET)}`);
+        // console.debug(
+        //   `contextWord.word: ${contextWord.word} TAG_WORD_SET: ${Array.from(
+        //     WorkspaceTagList.TAG_WORD_SET
+        //   )}`
+        // );
         items = Array.from(WorkspaceTagList.TAG_WORD_SET).map((t) => {
           let kind = CompletionItemKind.File;
           let label = `${t}`; // cast to a string


### PR DESCRIPTION
- add `range` to each `CompletionItem` returned (to try to fix intermittent failure of `#tag` completion
- fix typos
- upgrade to `vsce` 1.75.0


[This stackoverflow answer](https://stackoverflow.com/a/61723881/382912) suggested that intermittent failure to show suggestions (despite a non-empty list of CompletionItems being returned by `provideCompletionItems`) was due to not returning a `range` on each CompletionItem, which would default the range to the current word range -- [constructor docs](https://code.visualstudio.com/api/references/vscode-api#CompletionItem):

> range?: Range | {inserting: Range, replacing: Range}
>
> A range or a insert and replace range selecting the text that should be replaced by this completion item.
>
> When omitted, the range of the current word is used as replace-range and as insert-range the start of the current word to the current position is used.
>
> Note 1: A range must be a single line and it must contain the position at which completion has been requested. Note 2: A insert range must be a prefix of a replace range, that means it must be contained and starting at the same position.

My current hypothesis with some intermittent failures is that there may be an race condition / conflict with other extensions setting the markdwon `wordPattern` with `vscode.languages.setLanguageConfiguration`, so hopefully explicit setting of range will fix that.

Per [this stackoverflow](https://stackoverflow.com/a/60125444/382912), as of 1.42.0, `cmd+shift+f` no longer adds the current word to the search, so I definitely want to do something like https://github.com/kortina/vscode-markdown-notes/pull/14 to support a quick command for searching the workspace for a tag.