### PR TITLE
Fix windows specific bugs while finding ref for tag

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ class WorkspaceTagList {
       )
       .map((f) => {
         // read file, get all words beginning with #, add to Set
-        readFile(f.path, (err, data) => {
+        readFile(f.fsPath, (err, data) => {
           let allWords = (data || '').toString().split(/\s/);
           let tags = allWords.filter((w) => w.match(TAG_REGEX_WITH_ANCHORS));
           tags.map((t) => this.TAG_WORD_SET.add(t));
@@ -133,7 +133,7 @@ export class ReferenceSearch {
       // TODO: parameterize extensions. Add $ to end?
       (f) => f.scheme == 'file' && f.path.match(/\.(md|markdown)/i)
     );
-    let paths = files.map((f) => f.path);
+    let paths = files.map((f) => f.fsPath);
     let fileBuffers = await Promise.all(paths.map((p) => fsp.readFile(p)));
     fileBuffers.map((data, i) => {
       let path = files[i].path;
@@ -328,7 +328,7 @@ class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
       const filename = selectedWord;
       // there should be exactly 1 file with name = selectedWord
       files = (await workspace.findFiles('**/*')).filter((f) => {
-        return basename(f.path) == filename;
+        return basename(f.fsPath) == filename;
       });
     }
     // If we did not find any files in the workspace,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ export class ReferenceSearch {
     if (!queryWord) {
       return [];
     }
-    let lines = data.split(/[\r\n]/);
+    let lines = data.split(/\r?\n/);
     lines.map((line, lineNum) => {
       let charNum = 0;
       // https://stackoverflow.com/questions/17726904/javascript-splitting-a-string-yet-preserving-the-spaces


### PR DESCRIPTION
Hi, thanks for the extension! I meet some bugs while using on Windows.


**1. The find all reference doesn't work, it raises errors:**

![image](https://user-images.githubusercontent.com/657962/82138772-03823980-97f1-11ea-9f50-61c61c4bc5dc.png)

Should use uri.fsPath instead of uri.path for disk operations
Doc: https://code.visualstudio.com/api/references/vscode-api#Uri

fixed by 8eb7465

**2. The file content in Tags reference is not correct. Turns out the lines are not correct splited.**
Fixed by 110809e 


I've tested it on macOS. Works fine.