### PR TITLE
configurable template for new notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-markdown-notes",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
           "type": "boolean",
           "default": true,
           "description": "By default, when invoking `editor.action.revealDefinition` on `[[note.md]]` if `note.md` does not exist in workspace, create it. NB: Works only when `vscodeMarkdownNotes.workspaceFilenameConvention` = 'uniqueFilenames'."
+        },
+        "vscodeMarkdownNotes.newNoteTemplate": {
+          "type": "string",
+          "default": "# ${noteName}\n\n",
+          "description": "template for auto-created note files. Available tokens: ${noteName}, ${timestamp}"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "vscodeMarkdownNotes.newNoteTemplate": {
           "type": "string",
           "default": "# ${noteName}\n\n",
-          "description": "template for auto-created note files. Available tokens: ${noteName}, ${timestamp}"
+          "description": "Template for auto-created note files. Available tokens: ${noteName}, ${timestamp}. Timestamp is inserted in ISO format, i.e. 2020-07-09T05:29:00.541Z."
         }
       }
     },

--- a/src/MarkdownDefinitionProvider.ts
+++ b/src/MarkdownDefinitionProvider.ts
@@ -99,7 +99,8 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
       // TODO: could convert this to an option (to, eg, create in workspace root)
       const path = join(dirname(filename), mdFilename);
       const title = titleCaseFilename(ref.word);
-      writeFileSync(path, `# ${title}\n\n`);
+      const content = NoteWorkspace.newNoteContent(title);
+      writeFileSync(path, content);
       return path;
     }
   };

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -166,16 +166,14 @@ describe('NoteWorkspace.newNoteContent', () => {
   });
 
   it('handles timestamp', () => {
-    const template = "# Title\n\nCreated: ${timestamp}\n Last modified: ${timestamp}";
+    const template = "# Title\n\nCreated: ${timestamp}\n";
     
     const content = newNote(template, 'nevermind');
-    const regex = /# Title\n\nCreated: (.*)\n Last modified: (.*)/;
+    const regex = /# Title\n\nCreated: (.*)\n/;
     
     expect(content).toMatch(regex);
     const matches = regex.exec(content);
     const date1 = Date.parse(matches![1]);
     expect(date1).not.toBe(Number.NaN);
-    const date2 = Date.parse(matches![2]);
-    expect(date2).not.toBe(Number.NaN);
   });
 });

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -137,3 +137,45 @@ test('Note.tagSet', () => {
   let tags = Note.fromData(document).tagSet();
   expect(tags).toEqual(new Set(['#another_tag', '#tag']));
 });
+
+describe('NoteWorkspace.newNoteContent', () => {
+  const newNote = (template: string, title: string) => {
+    NoteWorkspace.cfg = () => {
+      return {
+        ...NoteWorkspace.DEFAULT_CONFIG,
+        newNoteTemplate: template
+      }
+    };
+  
+    return NoteWorkspace.newNoteContent(title);
+  }
+  it('handles noteName tag', () => {
+    const template = "# ${noteName}\n\nThis is ${noteName}";
+    
+    const content = newNote(template, "this is my test note!");
+
+    expect(content).toBe('# this is my test note!\n\nThis is this is my test note!')
+  });
+
+  it('handles escaped newlines', () => {
+    const template = "# Title\\n\\nContent";
+    
+    const content = newNote(template, 'nevermind');
+
+    expect(content).toBe('# Title\n\nContent');
+  });
+
+  it('handles timestamp', () => {
+    const template = "# Title\n\nCreated: ${timestamp}\n Last modified: ${timestamp}";
+    
+    const content = newNote(template, 'nevermind');
+    const regex = /# Title\n\nCreated: (.*)\n Last modified: (.*)/;
+    
+    expect(content).toMatch(regex);
+    const matches = regex.exec(content);
+    const date1 = Date.parse(matches![1]);
+    expect(date1).not.toBe(Number.NaN);
+    const date2 = Date.parse(matches![2]);
+    expect(date2).not.toBe(Number.NaN);
+  });
+});


### PR DESCRIPTION
A minimal solution for #48. 
New note template is configurable via `vscodeMarkdownNotes.newNoteTemplate` and defaults to old template, which was previously hard-coded.