### PR TITLE
fix bug where selector was not registering for mdx. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-markdown-notes",
   "displayName": "Markdown Notes",
   "description": "Navigate notes with [[wiki-links]], backlinks, and #tags (like Bear, Roam, etc). Automatically create notes from new inline [[wiki-links]]. Use Peek Definition to preview linked notes.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "publisher": "kortina",
   "repository": {
     "url": "https://github.com/kortina/vscode-markdown-notes.git",
@@ -37,7 +37,8 @@
         "scopeName": "text.markdown.notes",
         "path": "./syntaxes/notes.tmLanguage.json",
         "injectTo": [
-          "text.html.markdown"
+          "text.html.markdown",
+          "text.html.markdown.jsx"
         ]
       }
     ],

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -52,6 +52,12 @@ export class NoteWorkspace {
     slugifyCharacter: SlugifyCharacter.dash,
     workspaceFilenameConvention: WorkspaceFilenameConvention.uniqueFilenames,
   };
+  static DOCUMENT_SELECTOR = [
+    // { scheme: 'file', language: 'markdown' },
+    // { scheme: 'file', language: 'mdx' },
+    { language: 'markdown' },
+    { language: 'mdx' },
+  ];
 
   static cfg(): Config {
     let c = vscode.workspace.getConfiguration('vscodeMarkdownNotes');
@@ -228,8 +234,10 @@ export class NoteWorkspace {
 
   static overrideMarkdownWordPattern() {
     // console.debug('overrideMarkdownWordPattern');
-    vscode.languages.setLanguageConfiguration('markdown', {
-      wordPattern: this.rxMarkdownWordPattern(),
+    this.DOCUMENT_SELECTOR.map((ds) => {
+      vscode.languages.setLanguageConfiguration(ds.language, {
+        wordPattern: this.rxMarkdownWordPattern(),
+      });
     });
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,18 +10,18 @@ import { NoteParser } from './NoteParser';
 
 export function activate(context: vscode.ExtensionContext) {
   // console.debug('vscode-markdown-notes.activate');
-  const md = { scheme: 'file', language: 'markdown' };
+  const ds = NoteWorkspace.DOCUMENT_SELECTOR;
   NoteWorkspace.overrideMarkdownWordPattern(); // still nec to get ../ to trigger suggestions in `relativePaths` mode
 
   context.subscriptions.push(
-    vscode.languages.registerCompletionItemProvider(md, new MarkdownFileCompletionItemProvider())
+    vscode.languages.registerCompletionItemProvider(ds, new MarkdownFileCompletionItemProvider())
   );
   context.subscriptions.push(
-    vscode.languages.registerDefinitionProvider(md, new MarkdownDefinitionProvider())
+    vscode.languages.registerDefinitionProvider(ds, new MarkdownDefinitionProvider())
   );
 
   context.subscriptions.push(
-    vscode.languages.registerReferenceProvider(md, new MarkdownReferenceProvider())
+    vscode.languages.registerReferenceProvider(ds, new MarkdownReferenceProvider())
   );
 
   vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {


### PR DESCRIPTION
- make document selector style Array<>
- remove scheme: 'file' from DocumentSelector


https://github.com/formulahendry/vscode-auto-close-tag/search?q=activationOnLanguage&unscoped_q=activationOnLanguage

Closes #45