### PR TITLE
fix for 'noteNamesFuzzyMatch'

### DIFF
--- a/src/NoteParser.ts
+++ b/src/NoteParser.ts
@@ -41,7 +41,7 @@ class RefCandidate {
     if (ref.type == RefType.Tag) {
       return this.rawText == `#${ref.word}`;
     } else if (ref.type == RefType.WikiLink) {
-      return NoteWorkspace.noteNamesFuzzyMatch(this.rawText, ref.word);
+      return NoteWorkspace.noteNamesFuzzyMatchText(this.rawText, ref.word);
     }
     return false;
   }

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -152,10 +152,24 @@ export class NoteWorkspace {
     return n;
   }
 
+  static normalizeNoteNameForFuzzyMatchText(noteName: string): string {
+    // remove the brackets:
+    let n = noteName.replace(/[\[\]]/g, '');    
+    // remove the extension:
+    n = this.stripExtension(n);
+    // slugify (to normalize spaces)
+    n = this.slugifyTitle(n);
+    return n;
+  }
+
   // Compare 2 wiki-links for a fuzzy match.
   // All of the following will return true
   static noteNamesFuzzyMatch(left: string, right: string): boolean {
-    return this.normalizeNoteNameForFuzzyMatch(left) == this.normalizeNoteNameForFuzzyMatch(right);
+    return this.normalizeNoteNameForFuzzyMatch(left).toLowerCase() == this.normalizeNoteNameForFuzzyMatchText(right).toLowerCase();
+  }
+
+  static noteNamesFuzzyMatchText(left: string, right: string): boolean {
+    return this.normalizeNoteNameForFuzzyMatchText(left).toLowerCase() == this.normalizeNoteNameForFuzzyMatchText(right).toLowerCase();
   }
 
   static slugifyTitle(title: string): string {

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -71,6 +71,43 @@ test('noteNamesFuzzyMatch', () => {
   // expect(NoteWorkspace.noteNamesFuzzyMatch('[[wiki link#with-heading]]', 'wiki-link.md')).toBeTruthy();
 });
 
+test('noteNamesFuzzyMatchSlashes', () => {
+  expect(NoteWorkspace.normalizeNoteNameForFuzzyMatch('dir/sub/link-topic.md')).toEqual(
+    'link-topic'
+  );
+  // lower case is expected because 'slugifyTitle' includes toLowerCase
+  expect(NoteWorkspace.slugifyTitle('Link/Topic')).toEqual(
+    'link-topic'
+  );
+  expect(NoteWorkspace.normalizeNoteNameForFuzzyMatchText('Link/Topic')).toEqual(
+    'link-topic'
+  );  
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/link-topic.md', 'Link/Topic')
+  ).toBeTruthy();
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/Link-Topic.md', 'Link/Topic')
+  ).toBeTruthy();
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/link-topic.md', 'link/topic')
+  ).toBeTruthy();
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/Link-Topic.md', 'link/topic')
+  ).toBeTruthy();
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/link-topic.md', 'Link/topic')
+  ).toBeTruthy();
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/link-topic.md', 'link/Topic')
+  ).toBeTruthy();
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/Link-Topic.md', 'Link/topic')
+  ).toBeTruthy();
+  expect(
+    NoteWorkspace.noteNamesFuzzyMatch('dir/sub/Link-Topic.md', 'link/Topic')
+  ).toBeTruthy();
+});
+
 test('noteNamesFuzzyMatch', () => {
   expect(NoteWorkspace._wikiLinkCompletionForConvention('toSpaces', 'the-note-name.md')).toEqual(
     'the note name'


### PR DESCRIPTION
wiki-links containing a '/' created a not needed new file
possible fix for #50 