### PR TITLE
Fix for accented URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-markdown-notes",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -160,7 +160,6 @@ export class NoteWorkspace {
 
   static slugifyTitle(title: string): string {
     return title
-      .normalize("NFD").replace(/[\u0300-\u036f]/g, "") // Remove accents
       .replace(/[!"\#$%&'()*+,\-./:;<=>?@\[\\\]^_‘{|}~\s]+/gi, this.slugifyChar()) // punctuation and whitespace to hyphens (or underscores)
       .toLowerCase() // lower
       .replace(/[-_]*$/, ''); // removing trailing '-' and '_' chars

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -160,6 +160,7 @@ export class NoteWorkspace {
 
   static slugifyTitle(title: string): string {
     return title
+      .normalize("NFD").replace(/[\u0300-\u036f]/g, "") // Remove accents
       .replace(/\W+/gi, this.slugifyChar()) // non-words to hyphens (or underscores)
       .toLowerCase() // lower
       .replace(/[-_]*$/, ''); // removing trailing '-' and '_' chars

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -161,7 +161,7 @@ export class NoteWorkspace {
   static slugifyTitle(title: string): string {
     return title
       .normalize("NFD").replace(/[\u0300-\u036f]/g, "") // Remove accents
-      .replace(/\W+/gi, this.slugifyChar()) // non-words to hyphens (or underscores)
+      .replace(/[!"\#$%&'()*+,\-./:;<=>?@\[\\\]^_‘{|}~\s]+/gi, this.slugifyChar()) // punctuation and whitespace to hyphens (or underscores)
       .toLowerCase() // lower
       .replace(/[-_]*$/, ''); // removing trailing '-' and '_' chars
   }

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -160,15 +160,18 @@ export class NoteWorkspace {
     return this.normalizeNoteNameForFuzzyMatch(left) == this.normalizeNoteNameForFuzzyMatch(right);
   }
 
+  static cleanTitle (title: string): string {
+    return title.toLowerCase() // lower
+      .replace(/[-_－＿ ]*$/g, ''); // removing trailing slug chars
+  }
   static slugifyTitle(title: string): string {
-    return title
-      .replace(/[!"\#$%&'()*+,\-./:;<=>?@\[\\\]^_‘{|}~\s]+/gi, this.slugifyChar()) // punctuation and whitespace to hyphens (or underscores)
-      .toLowerCase() // lower
-      .replace(/[-_－＿]*$/, ''); // removing trailing '-' and '_' chars
+    return this.slugifyChar() == 'NONE' ? 
+      title :
+      title.replace(/[!"\#$%&'()*+,\-./:;<=>?@\[\\\]^_‘{|}~\s]+/gi, this.slugifyChar()); // punctuation and whitespace to hyphens (or underscores)
   }
 
   static noteFileNameFromTitle(title: string): string {
-    let t = this.slugifyChar() == this.SLUGIFY_NONE ? title : this.slugifyTitle(title);
+    let t = this.cleanTitle(this.slugifyTitle(title));
     return t.match(this.rxFileExtensions()) ? t : `${t}.${this.defaultFileExtension()}`;
   }
 

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -18,6 +18,8 @@ enum WorkspaceFilenameConvention {
 enum SlugifyCharacter {
   dash = '-',
   underscore = '_',
+  fullwidthDash = '－',
+  fullwidthUnderscore = '＿',
   none = 'NONE',
 }
 

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -164,7 +164,7 @@ export class NoteWorkspace {
     return title
       .replace(/[!"\#$%&'()*+,\-./:;<=>?@\[\\\]^_‘{|}~\s]+/gi, this.slugifyChar()) // punctuation and whitespace to hyphens (or underscores)
       .toLowerCase() // lower
-      .replace(/[-_]*$/, ''); // removing trailing '-' and '_' chars
+      .replace(/[-_－＿]*$/, ''); // removing trailing '-' and '_' chars
   }
 
   static noteFileNameFromTitle(title: string): string {

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -25,7 +25,8 @@ test('noteFileNameFromTitle', () => {
   NoteWorkspace.slugifyChar = (): string => '_';
   expect(NoteWorkspace.noteFileNameFromTitle('Some   Title ')).toEqual('some_title.md');
   NoteWorkspace.slugifyChar = (): string => '-';
-  expect(NoteWorkspace.noteFileNameFromTitle('Šömè Títlê')).toEqual('some-title.md');
+  expect(NoteWorkspace.noteFileNameFromTitle('タイトル')).toEqual('タイトル.md');
+  NoteWorkspace.slugifyChar = (): string => '-';
   NoteWorkspace.slugifyChar = orig;
 });
 

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -24,6 +24,8 @@ test('noteFileNameFromTitle', () => {
   expect(NoteWorkspace.noteFileNameFromTitle('Some " Title ')).toEqual('some-title.md');
   NoteWorkspace.slugifyChar = (): string => '_';
   expect(NoteWorkspace.noteFileNameFromTitle('Some   Title ')).toEqual('some_title.md');
+  NoteWorkspace.slugifyChar = (): string => '-';
+  expect(NoteWorkspace.noteFileNameFromTitle('Šömè Títlê')).toEqual('some-title.md');
   NoteWorkspace.slugifyChar = orig;
 });
 

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -25,8 +25,9 @@ test('noteFileNameFromTitle', () => {
   NoteWorkspace.slugifyChar = (): string => '_';
   expect(NoteWorkspace.noteFileNameFromTitle('Some   Title ')).toEqual('some_title.md');
   NoteWorkspace.slugifyChar = (): string => '-';
-  expect(NoteWorkspace.noteFileNameFromTitle('タイトル')).toEqual('タイトル.md');
+  expect(NoteWorkspace.noteFileNameFromTitle('Šömè Țítlê')).toEqual('šömè-țítlê.md');
   NoteWorkspace.slugifyChar = (): string => '-';
+  expect(NoteWorkspace.noteFileNameFromTitle('タイトル')).toEqual('タイトル.md');
   NoteWorkspace.slugifyChar = orig;
 });
 

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -19,9 +19,9 @@ test('foo', () => {
 test('noteFileNameFromTitle', () => {
   let orig = NoteWorkspace.slugifyChar;
   NoteWorkspace.slugifyChar = (): string => 'NONE';
-  expect(NoteWorkspace.noteFileNameFromTitle('Some Title')).toEqual('Some Title.md');
-  //NoteWorkspace.slugifyChar = (): string => 'NONE';
-  //expect(NoteWorkspace.noteFileNameFromTitle('Some Title ')).toEqual('Some Title.md');
+  expect(NoteWorkspace.noteFileNameFromTitle('Some Title')).toEqual('some title.md');
+  NoteWorkspace.slugifyChar = (): string => 'NONE';
+  expect(NoteWorkspace.noteFileNameFromTitle('Some Title ')).toEqual('some title.md');
   NoteWorkspace.slugifyChar = (): string => '-';
   expect(NoteWorkspace.noteFileNameFromTitle('Some " Title ')).toEqual('some-title.md');
   NoteWorkspace.slugifyChar = (): string => '_';

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -28,8 +28,8 @@ test('noteFileNameFromTitle', () => {
   expect(NoteWorkspace.noteFileNameFromTitle('Šömè Țítlê')).toEqual('šömè-țítlê.md');
   NoteWorkspace.slugifyChar = (): string => '-';
   expect(NoteWorkspace.noteFileNameFromTitle('題目')).toEqual('題目.md');
-  NoteWorkspace.slugifyChar = (): string => '-';
-  expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ')).toEqual('ｓｏｍｅ-ｔｉｔｌｅ.md');
+  NoteWorkspace.slugifyChar = (): string => '－';
+  expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ')).toEqual('ｓｏｍｅ－ｔｉｔｌｅ.md');
   
   NoteWorkspace.slugifyChar = orig;
 });

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -20,6 +20,8 @@ test('noteFileNameFromTitle', () => {
   let orig = NoteWorkspace.slugifyChar;
   NoteWorkspace.slugifyChar = (): string => 'NONE';
   expect(NoteWorkspace.noteFileNameFromTitle('Some Title')).toEqual('Some Title.md');
+  //NoteWorkspace.slugifyChar = (): string => 'NONE';
+  //expect(NoteWorkspace.noteFileNameFromTitle('Some Title ')).toEqual('Some Title.md');
   NoteWorkspace.slugifyChar = (): string => '-';
   expect(NoteWorkspace.noteFileNameFromTitle('Some " Title ')).toEqual('some-title.md');
   NoteWorkspace.slugifyChar = (): string => '_';
@@ -30,6 +32,8 @@ test('noteFileNameFromTitle', () => {
   expect(NoteWorkspace.noteFileNameFromTitle('題目')).toEqual('題目.md');
   NoteWorkspace.slugifyChar = (): string => '－';
   expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ')).toEqual('ｓｏｍｅ－ｔｉｔｌｅ.md');
+  NoteWorkspace.slugifyChar = (): string => '－';
+  expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ ')).toEqual('ｓｏｍｅ－ｔｉｔｌｅ.md');
   
   NoteWorkspace.slugifyChar = orig;
 });

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -27,7 +27,8 @@ test('noteFileNameFromTitle', () => {
   NoteWorkspace.slugifyChar = (): string => '-';
   expect(NoteWorkspace.noteFileNameFromTitle('Šömè Țítlê')).toEqual('šömè-țítlê.md');
   NoteWorkspace.slugifyChar = (): string => '-';
-  expect(NoteWorkspace.noteFileNameFromTitle('タイトル')).toEqual('タイトル.md');
+  expect(NoteWorkspace.noteFileNameFromTitle('題目')).toEqual('題目.md');
+  
   NoteWorkspace.slugifyChar = orig;
 });
 

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -28,6 +28,8 @@ test('noteFileNameFromTitle', () => {
   expect(NoteWorkspace.noteFileNameFromTitle('Šömè Țítlê')).toEqual('šömè-țítlê.md');
   NoteWorkspace.slugifyChar = (): string => '-';
   expect(NoteWorkspace.noteFileNameFromTitle('題目')).toEqual('題目.md');
+  NoteWorkspace.slugifyChar = (): string => '-';
+  expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ')).toEqual('ｓｏｍｅ-ｔｉｔｌｅ.md');
   
   NoteWorkspace.slugifyChar = orig;
 });


### PR DESCRIPTION
As mentioned in #47 there is an issue when a document has an accent in the URL.

I've written the following test:

```
expect(NoteWorkspace.noteFileNameFromTitle('Šömè Títlê')).toEqual('some-title.md');
```

Previously it would have generated a file called `m-ttl.md`. I believe although the solution I've suggested isn't perfect, it reads better than previous.

Would you prefer this behaviour, actually using accents in the URLs or a flag to opt into this behaviour?
