### PR TITLE
fix bug that Go to reference will cause auto-complete for wiki links all the time

### DIFF
--- a/src/NoteParser.ts
+++ b/src/NoteParser.ts
@@ -253,7 +253,7 @@ export class NoteParser {
     let query: string;
     if (ref.type == RefType.Tag) {
       query = `#${ref.word}`;
-    } else if ((ref.type = RefType.WikiLink)) {
+    } else if (ref.type == RefType.WikiLink) {
       query = `[[${basename(ref.word)}]]`;
     } else {
       return [];


### PR DESCRIPTION
fix bug, https://github.com/kortina/vscode-markdown-notes/issues/58

when using `Go to Reference` outside `[[]]`, the `NULL_REF.type` will set to `RefType.WikiLink`, which causes the auto-complete for wiki links all the time.

