### PR TITLE
Add support for Unicode tags or filenames.

### DIFF
--- a/src/MarkdownFileCompletionItemProvider.ts
+++ b/src/MarkdownFileCompletionItemProvider.ts
@@ -17,13 +17,11 @@ export class MarkdownFileCompletionItemProvider implements vscode.CompletionItem
     context: vscode.CompletionContext
   ) {
     const ref = getRefAt(document, position);
-    let items = [];
     switch (ref.type) {
       case RefType.Null:
         return [];
-        break;
       case RefType.Tag:
-        items = (await NoteParser.distinctTags()).map((t) => {
+        return (await NoteParser.distinctTags()).map((t) => {
           let kind = vscode.CompletionItemKind.File;
           let label = `${t}`; // cast to a string
           let item = new vscode.CompletionItem(label, kind);
@@ -32,11 +30,8 @@ export class MarkdownFileCompletionItemProvider implements vscode.CompletionItem
           }
           return item;
         });
-        return items;
-        break;
       case RefType.WikiLink:
-        let files = await NoteWorkspace.noteFiles();
-        items = files.map((f) => {
+        return (await NoteWorkspace.noteFiles()).map((f) => {
           let kind = vscode.CompletionItemKind.File;
           let label = NoteWorkspace.wikiLinkCompletionForConvention(f, document);
           let item = new vscode.CompletionItem(label, kind);
@@ -45,11 +40,6 @@ export class MarkdownFileCompletionItemProvider implements vscode.CompletionItem
           }
           return item;
         });
-        return items;
-        break;
-      default:
-        return [];
-        break;
     }
   }
 }

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -39,10 +39,10 @@ type Config = {
 export class NoteWorkspace {
   // Defining these as strings now, and then compiling them with accessor methods.
   // This will allow us to potentially expose these as settings.
-  static _rxTagNoAnchors = '\\#[\\w\\-\\_]+'; // used to match tags that appear within lines
-  static _rxTagWithAnchors = '^\\#[\\w\\-\\_]+$'; // used to match entire words
+  static _rxTagNoAnchors = '\\#[\\w\\p{L}\\-\\_]+'; // used to match tags that appear within lines
+  static _rxTagWithAnchors = '^\\#[\\w\\p{L}\\-\\_]+$'; // used to match entire words
   static _rxWikiLink = '\\[\\[[^\\]]+\\]\\]'; // [[wiki-link-regex]]
-  static _rxMarkdownWordPattern = '([\\_\\w\\#\\.\\/\\\\]+)'; // had to add [".", "/", "\"] to get relative path completion working and ["#"] to get tag completion working
+  static _rxMarkdownWordPattern = '([\\_\\w\\p{L}\\#\\.\\/\\\\]+)'; // had to add [".", "/", "\"] to get relative path completion working and ["#"] to get tag completion working
   static _rxFileExtensions = '\\.(md|markdown|mdx|fountain)$';
   static _defaultFileExtension = 'md';
   static _defaultNoteTemplate = '# ${noteName}\n\n';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { MarkdownReferenceProvider } from './MarkdownReferenceProvider';
 import { MarkdownFileCompletionItemProvider } from './MarkdownFileCompletionItemProvider';
 import { NoteWorkspace } from './NoteWorkspace';
 import { NoteParser } from './NoteParser';
+import { getRefAt, RefType } from './Ref';
 // import { debug } from 'util';
 // import { create } from 'domain';
 
@@ -26,6 +27,14 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
     NoteParser.updateCacheFor(e.document.uri.fsPath);
+    
+    const shouldSuggest = e.contentChanges.some((change) => {
+      const ref = getRefAt(e.document, change.range.end);
+      return ref.type != RefType.Null && change.rangeLength > ref.word.length;
+    });
+    if (shouldSuggest) {
+      vscode.commands.executeCommand('editor.action.triggerSuggest');
+    }
   });
 
   let newNoteDisposable = vscode.commands.registerCommand(

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -59,7 +59,9 @@ test('rxWikiLink', () => {
   let rx = NoteWorkspace.rxWikiLink();
   expect(('Some [[wiki-link]].'.match(rx) || [])[0]).toEqual('[[wiki-link]]');
   expect(('Some [[wiki link]].'.match(rx) || [])[0]).toEqual('[[wiki link]]');
+  expect(('一段 [[链接]]。'.match(rx) || [])[0]).toEqual('[[链接]]');
   expect(('Some [[wiki-link.md]].'.match(rx) || [])[0]).toEqual('[[wiki-link.md]]');
+  expect(('一段 [[链接.md]]。'.match(rx) || [])[0]).toEqual('[[链接.md]]');
   // TODO: this returns a match OK right now, but I think we will want to
   // modify the result to contain meta-data that says there is also a #heading / parses it out
   expect(('Some [[wiki-link.md#with-heading]].'.match(rx) || [])[0]).toEqual(
@@ -67,6 +69,7 @@ test('rxWikiLink', () => {
   );
   // Should the following work? It does....
   expect(('Some[[wiki-link.md]]no-space.'.match(rx) || [])[0]).toEqual('[[wiki-link.md]]');
+  expect(('一段[[链接]]无空格。'.match(rx) || [])[0]).toEqual('[[链接]]');
   expect('Some [[wiki-link.md].').not.toMatch(rx);
 });
 
@@ -83,6 +86,7 @@ test('noteNamesFuzzyMatch', () => {
   expect(NoteWorkspace.noteNamesFuzzyMatch('[[wiki-link.md]]', 'wiki-link.md')).toBeTruthy();
   expect(NoteWorkspace.noteNamesFuzzyMatch('[[wiki-link]]', 'wiki-link.md')).toBeTruthy();
   expect(NoteWorkspace.noteNamesFuzzyMatch('[[wiki link]]', 'wiki-link.md')).toBeTruthy();
+  expect(NoteWorkspace.noteNamesFuzzyMatch('[[链接]]', '链接.md')).toBeTruthy();
   // TODO: if we add support for #headings, we will want these tests to pass:
   // expect(NoteWorkspace.noteNamesFuzzyMatch('[[wiki-link.md#with-heading]]', 'wiki-link.md')).toBeTruthy();
   // expect(NoteWorkspace.noteNamesFuzzyMatch('[[wiki-link#with-heading]]', 'wiki-link.md')).toBeTruthy();
@@ -199,17 +203,17 @@ describe('NoteWorkspace.newNoteContent', () => {
       return {
         ...NoteWorkspace.DEFAULT_CONFIG,
         newNoteTemplate: template
-      }
+      };
     };
   
     return NoteWorkspace.newNoteContent(title);
-  }
+  };
   it('handles noteName tag', () => {
     const template = "# ${noteName}\n\nThis is ${noteName}";
     
     const content = newNote(template, "this is my test note!");
 
-    expect(content).toBe('# this is my test note!\n\nThis is this is my test note!')
+    expect(content).toBe('# this is my test note!\n\nThis is this is my test note!');
   });
 
   it('handles escaped newlines', () => {

--- a/syntaxes/notes.tmLanguage.json
+++ b/syntaxes/notes.tmLanguage.json
@@ -19,7 +19,7 @@
       }
     },
     {
-      "match": "(\\#)([\\w\\-\\_]+)",
+      "match": "(\\#)([\\w\\p{L}\\-\\_]+)",
       "name": "text.markdown.notes.tag",
       "captures": {
         "1": {


### PR DESCRIPTION
Well, just a simple and quick fix. I personally use Chinese and Japanese frequently, but our extension cannot autocomplete the tags/filenames in Unicode characters. So I spent a little time and propose this small fix here.