### PR TITLE
add vscodeMarkdownNotes.newNoteDirectory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-markdown-notes",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-markdown-notes",
   "displayName": "Markdown Notes",
   "description": "Navigate notes with [[wiki-links]], backlinks, and #tags (like Bear, Roam, etc). Automatically create notes from new inline [[wiki-links]]. Use Peek Definition to preview linked notes.",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "publisher": "kortina",
   "repository": {
     "url": "https://github.com/kortina/vscode-markdown-notes.git",
@@ -89,6 +89,11 @@
           "type": "boolean",
           "default": true,
           "description": "By default, when invoking `editor.action.revealDefinition` on `[[note.md]]` if `note.md` does not exist in workspace, create it. NB: Works only when `vscodeMarkdownNotes.workspaceFilenameConvention` = 'uniqueFilenames'."
+        },
+        "vscodeMarkdownNotes.newNoteDirectory": {
+          "type": "string",
+          "default": "SAME_AS_ACTIVE_NOTE",
+          "description": "Directory for creating new notes. Defaults to 'SAME_AS_ACTIVE_NOTE'; you can also use 'WORKSPACE_ROOT'; or a 'subdirectory/path' in the Workspace Root."
         },
         "vscodeMarkdownNotes.newNoteTemplate": {
           "type": "string",

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -1,6 +1,6 @@
 import 'jest';
 import { foo, NoteWorkspace } from '../../NoteWorkspace';
-import { titleCaseFilename } from '../../utils';
+import { titleCaseFromFilename } from '../../utils';
 import { Note, NoteParser } from '../../NoteParser';
 import { RefType } from '../../Ref';
 import { config } from 'process';
@@ -124,9 +124,9 @@ test('noteNamesFuzzyMatch', () => {
   // TODO: how should this behaving with #headings?
 });
 
-test('titleCaseFilename', () => {
-  expect(titleCaseFilename('the-heat-is-on.md')).toEqual('The Heat Is On');
-  expect(titleCaseFilename('in-the-heat-of-the-night.md')).toEqual('In the Heat of the Night');
+test('titleCaseFromFilename', () => {
+  expect(titleCaseFromFilename('the-heat-is-on.md')).toEqual('The Heat Is On');
+  expect(titleCaseFromFilename('in-the-heat-of-the-night.md')).toEqual('In the Heat of the Night');
 });
 
 let document = `line0 word1

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ underneath unlike until up upon versus via with within without yet
 };
 
 // take some-filename-in-case to "Some Filename in Case" Title
-export const titleCaseFilename = (filename: string): string => {
+export const titleCaseFromFilename = (filename: string): string => {
   if (!filename) {
     return filename;
   }


### PR DESCRIPTION
Resolve #74

**Enhancements:**

- add setting `vscodeMarkdownNotes.newNoteDirectory`, can be set to:
  - `SAME_AS_ACTIVE_NOTE`
  - `WORKSPACE_ROOT`
  - or `subdirectory/path` in workspace root

