### PR TITLE
Merged preview extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-markdown-notes",
-  "version": "0.0.15",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1968,6 +1968,17 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@thomaskoppelaar/markdown-it-wikilinks": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@thomaskoppelaar/markdown-it-wikilinks/-/markdown-it-wikilinks-1.3.0.tgz",
+      "integrity": "sha512-yJTwX9dxwnjw7Kxi6hyP4gY3fLu6EMoTQRWSSGA3iCBZGCRhwCmYs4KIguFSZfgYag329MELnGguuGIy/lNRFQ==",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "markdown-it-regexp": "^0.4.0",
+        "sanitize-filename": "^1.6.1"
       }
     },
     "@types/babel__core": {
@@ -7165,6 +7176,12 @@
         }
       }
     },
+    "markdown-it-regexp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz",
+      "integrity": "sha1-1k1xPuzsVc5M/esyF1DswJniwtw=",
+      "dev": true
+    },
     "markdown-table": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -8515,6 +8532,15 @@
         }
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -9231,6 +9257,15 @@
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "ts-jest": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.0.0.tgz",
@@ -9695,6 +9730,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -136,12 +136,12 @@
           "default": true,
           "description": "Trigger suggest on both insertion AND replacement of new character inside a wiki-link. Defaults true. Set false to only trigger suggest on insertion. See PR #69 for details."
         },
-        "vscodeMarkdownNotes.showFileExtensionInPreview": {
+        "vscodeMarkdownNotes.previewShowFileExtension": {
           "type": "boolean",
           "default": false,
           "description": "Specifies whether or not to show the linked file's extension in the preview."
         },
-        "vscodeMarkdownNotes.previewlabelstyling": {
+        "vscodeMarkdownNotes.previewLabelStyling": {
           "type": "string",
           "default": "[[label]]",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "Programming Languages"
   ],
   "contributes": {
+    "markdown.markdownItPlugins": true,
     "languages": [
       {
         "id": "markdown-notes",
@@ -134,6 +135,21 @@
           "type": "boolean",
           "default": true,
           "description": "Trigger suggest on both insertion AND replacement of new character inside a wiki-link. Defaults true. Set false to only trigger suggest on insertion. See PR #69 for details."
+        },
+        "vscodeMarkdownNotes.showFileExtensionInPreview": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether or not to show the linked file's extension in the preview."
+        },
+        "vscodeMarkdownNotes.previewlabelstyling": {
+          "type": "string",
+          "default": "[[label]]",
+          "enum": [
+            "[[label]]",
+            "[label]",
+            "label"
+          ],
+          "description": "Changes how the link to a file should be shown, either with or without brackets."
         }
       }
     },
@@ -187,6 +203,7 @@
     "unified": "^9.0.0",
     "unist-util-find": "^1.0.1",
     "unist-util-visit": "^2.0.2",
+    "@thomaskoppelaar/markdown-it-wikilinks": "1.3.0",
     "vsce": "^1.75.0",
     "vscode-test": "^1.3.0"
   }

--- a/src/MarkdownRenderingPlugin.ts
+++ b/src/MarkdownRenderingPlugin.ts
@@ -50,3 +50,14 @@ export function postProcessLabel(label: string) {
     }
     ;
 }
+
+export function pluginSettings(): any {
+    return require('@thomaskoppelaar/markdown-it-wikilinks')({ 
+        generatePageNameFromLabel: PageNameGenerator, 
+        postProcessPageName: postProcessPageName, 
+        postProcessLabel: postProcessLabel,
+        uriSuffix: `.${NoteWorkspace.defaultFileExtension()}`,
+        description_then_file: NoteWorkspace.pipedWikiLinksSyntax() == "desc|file",
+        separator: NoteWorkspace.pipedWikiLinksSeparator(),
+    });
+}

--- a/src/MarkdownRenderingPlugin.ts
+++ b/src/MarkdownRenderingPlugin.ts
@@ -1,0 +1,52 @@
+import { MarkdownDefinitionProvider } from './MarkdownDefinitionProvider';
+import { NoteWorkspace } from './NoteWorkspace';
+import { RefType } from './Ref';
+
+// See also: https://github.com/tomleesm/markdown-it-wikilinks
+// Function that returns a filename based on the given wikilink.
+// Initially uses filesForWikiLinkRefFromCache() to try and find a matching file.
+// If this fails, it will attempt to make a (relative) link based on the label given.
+export function PageNameGenerator(label: string) {
+    const ref = {
+        type: RefType.WikiLink,
+        word: label,
+        hasExtension: false,
+        range: undefined
+    }
+    const results = MarkdownDefinitionProvider.filesForWikiLinkRefFromCache(ref, null);
+
+    label = label.replace(/\.[^\.\\\/]+$/, '');
+
+    // Either use the first result of the cache, or in the case that it's empty use the label to create a path
+    let path: string = (results.length != 0) ? results[0].path : NoteWorkspace.noteFileNameFromTitle(label);
+    
+    return path;
+}
+
+// Transformation that only gets applied to the page name (ex: the "test-file.md" part of [[test-file.md | Description goes here]]).
+export function postProcessPageName(pageName: string) {
+    return NoteWorkspace.stripExtension(pageName);
+}
+
+// Transformation that only gets applied to the link label (ex: the " Description goes here" part of [[test-file.md | Description goes here]])
+export function postProcessLabel(label: string) {
+    // Trim whitespaces
+    label = label.trim();
+    
+    // De-slugify label into whitespaces
+    label = label.split(NoteWorkspace.slugifyChar()).join(" ");
+
+    if (NoteWorkspace.showFileExtensionInPreview()) {
+        label += `.${NoteWorkspace.defaultFileExtension()}`;
+    }
+
+    switch (NoteWorkspace.previewLabelStyling()) {
+        case "[[label]]":
+            return `[[${label}]]`;
+        case "[label]":
+            return `[${label}]`;
+        case "label":
+            return label;
+    }
+    ;
+}

--- a/src/MarkdownRenderingPlugin.ts
+++ b/src/MarkdownRenderingPlugin.ts
@@ -15,7 +15,7 @@ export function PageNameGenerator(label: string) {
     }
     const results = MarkdownDefinitionProvider.filesForWikiLinkRefFromCache(ref, null);
 
-    label = label.replace(/\.[^\.\\\/]+$/, '');
+    label = NoteWorkspace.stripExtension(label);
 
     // Either use the first result of the cache, or in the case that it's empty use the label to create a path
     let path: string = (results.length != 0) ? results[0].path : NoteWorkspace.noteFileNameFromTitle(label);
@@ -36,7 +36,7 @@ export function postProcessLabel(label: string) {
     // De-slugify label into whitespaces
     label = label.split(NoteWorkspace.slugifyChar()).join(" ");
 
-    if (NoteWorkspace.showFileExtensionInPreview()) {
+    if (NoteWorkspace.previewShowFileExtension()) {
         label += `.${NoteWorkspace.defaultFileExtension()}`;
     }
 

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -48,7 +48,7 @@ type Config = {
   pipedWikiLinksSeparator: string;
   newNoteDirectory: string;
   previewLabelStyling: PreviewLabelStyling;
-  showFileExtensionInPreview: boolean;
+  previewShowFileExtension: boolean;
 };
 // This class contains:
 // 1. an interface to some of the basic user configurable settings or this extension
@@ -85,7 +85,7 @@ export class NoteWorkspace {
     pipedWikiLinksSeparator: '\\|',
     newNoteDirectory: NoteWorkspace.NEW_NOTE_SAME_AS_ACTIVE_NOTE,
     previewLabelStyling: PreviewLabelStyling.brackets,
-    showFileExtensionInPreview: false,
+    previewShowFileExtension: false,
   };
   static DOCUMENT_SELECTOR = [
     // { scheme: 'file', language: 'markdown' },
@@ -116,8 +116,8 @@ export class NoteWorkspace {
       pipedWikiLinksSyntax: c.get('pipedWikiLinksSyntax') as PipedWikiLinksSyntax,
       pipedWikiLinksSeparator: c.get('pipedWikiLinksSeparator') as string,
       newNoteDirectory: c.get('newNoteDirectory') as string,
-      previewLabelStyling: c.get('previewlabelstyling') as PreviewLabelStyling,
-      showFileExtensionInPreview: c.get('showFileExtensionInPreview') as boolean,
+      previewLabelStyling: c.get('previewLabelStyling') as PreviewLabelStyling,
+      previewShowFileExtension: c.get('previewShowFileExtension') as boolean,
     };
   }
 
@@ -157,8 +157,8 @@ export class NoteWorkspace {
       return this.cfg().previewLabelStyling;
   }
 
-  static showFileExtensionInPreview(): boolean {
-      return this.cfg().showFileExtensionInPreview;
+  static previewShowFileExtension(): boolean {
+      return this.cfg().previewShowFileExtension;
   }
 
   static rxTagNoAnchors(): RegExp {

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -28,6 +28,12 @@ enum PipedWikiLinksSyntax {
   descFile = 'desc|file',
 }
 
+enum PreviewLabelStyling {
+    brackets = "[[label]]",
+    bracket = "[label]",
+    none = "label"
+}
+
 type Config = {
   createNoteOnGoToDefinitionWhenMissing: boolean;
   defaultFileExtension: string;
@@ -41,6 +47,8 @@ type Config = {
   pipedWikiLinksSyntax: PipedWikiLinksSyntax;
   pipedWikiLinksSeparator: string;
   newNoteDirectory: string;
+  previewLabelStyling: PreviewLabelStyling;
+  showFileExtensionInPreview: boolean;
 };
 // This class contains:
 // 1. an interface to some of the basic user configurable settings or this extension
@@ -76,6 +84,8 @@ export class NoteWorkspace {
     pipedWikiLinksSyntax: PipedWikiLinksSyntax.descFile,
     pipedWikiLinksSeparator: '\\|',
     newNoteDirectory: NoteWorkspace.NEW_NOTE_SAME_AS_ACTIVE_NOTE,
+    previewLabelStyling: PreviewLabelStyling.brackets,
+    showFileExtensionInPreview: false,
   };
   static DOCUMENT_SELECTOR = [
     // { scheme: 'file', language: 'markdown' },
@@ -106,6 +116,8 @@ export class NoteWorkspace {
       pipedWikiLinksSyntax: c.get('pipedWikiLinksSyntax') as PipedWikiLinksSyntax,
       pipedWikiLinksSeparator: c.get('pipedWikiLinksSeparator') as string,
       newNoteDirectory: c.get('newNoteDirectory') as string,
+      previewLabelStyling: c.get('previewlabelstyling') as PreviewLabelStyling,
+      showFileExtensionInPreview: c.get('showFileExtensionInPreview') as boolean,
     };
   }
 
@@ -139,6 +151,14 @@ export class NoteWorkspace {
 
   static newNoteDirectory(): string {
     return this.cfg().newNoteDirectory;
+  }
+
+  static previewLabelStyling(): string {
+      return this.cfg().previewLabelStyling;
+  }
+
+  static showFileExtensionInPreview(): boolean {
+      return this.cfg().showFileExtensionInPreview;
   }
 
   static rxTagNoAnchors(): RegExp {

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -84,6 +84,9 @@ export class NoteWorkspace {
     { language: 'mdx' },
   ];
 
+  // Cache object to store results from noteFiles() in order to provide a synchronous method to the preview renderer.
+  static noteFileCache: vscode.Uri[] = [];
+
   static cfg(): Config {
     let c = vscode.workspace.getConfiguration('vscodeMarkdownNotes');
     return {
@@ -421,6 +424,11 @@ export class NoteWorkspace {
     let files = (await vscode.workspace.findFiles('**/*')).filter(
       (f) => f.scheme == 'file' && f.path.match(that.rxFileExtensions())
     );
+    this.noteFileCache = files;
     return files;
+  }
+
+  static noteFilesFromCache(): Array<vscode.Uri> {
+    return this.noteFileCache;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { MarkdownFileCompletionItemProvider } from './MarkdownFileCompletionItem
 import { NoteWorkspace } from './NoteWorkspace';
 import { NoteParser } from './NoteParser';
 import { getRefAt, RefType } from './Ref';
-import { PageNameGenerator, postProcessPageName, postProcessLabel, pluginSettings } from './MarkdownRenderingPlugin';
+import { pluginSettings } from './MarkdownRenderingPlugin';
 // import { debug } from 'util';
 // import { create } from 'domain';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,62 +7,9 @@ import { MarkdownFileCompletionItemProvider } from './MarkdownFileCompletionItem
 import { NoteWorkspace } from './NoteWorkspace';
 import { NoteParser } from './NoteParser';
 import { getRefAt, RefType } from './Ref';
+import { PageNameGenerator, postProcessPageName, postProcessLabel } from './MarkdownRenderingPlugin';
 // import { debug } from 'util';
 // import { create } from 'domain';
-
-let c = vscode.workspace.getConfiguration("vscodeMarkdownNotes");
-
-// Function that returns a filename based on the given wikilink.
-// Initially uses filesForWikiLinkRefFromCache() to try and find a matching file.
-// If this fails, it will attempt to make a (relative) link based on the label given.
-function PageNameGenerator(label: string) {
-    console.debug(label);
-    const ref = {
-        type: RefType.WikiLink,
-        word: label,
-        hasExtension: false,
-        range: undefined
-    }
-    const results = MarkdownDefinitionProvider.filesForWikiLinkRefFromCache(ref, null);
-
-    label = label.replace(/\.[^\.\\\/]+$/, '');
-
-    // Either use the first result of the cache, or in the case that it's empty use the label to create a path
-    let path: string = (results.length != 0) ? results[0].path : NoteWorkspace.noteFileNameFromTitle(label);
-    
-    return path;
-}
-
-function postProcessPageName(pageName: string) {
-    pageName = pageName.trim();
-    pageName = pageName.replace(/\.[^\.\\\/]+$/, '');
-
-    return pageName;
-
-}
-  
-function postProcessLabel(label: string) {
-	label = label.trim();
-	
-	// Remove filename extension
-	label = label.replace(/\.[^/.]+$/, "");
-    
-    
-    label = label.split(`${c.get('slugifyCharacter')}`).join(" ");
-    if (c.get('showFileExtensionInPreview')) {
-        label += `.${c.get('defaultFileExtension')}`;
-    }
-
-    switch (c.get('previewlabelstyling')) {
-        case "[[label]]":
-            return `[[${label}]]`;
-        case "[label]":
-            return `[${label}]`;
-        case "label":
-            return label;
-    }
-    ;
-}
 
 export function activate(context: vscode.ExtensionContext) {
   // console.debug('vscode-markdown-notes.activate');
@@ -127,9 +74,9 @@ export function activate(context: vscode.ExtensionContext) {
                 generatePageNameFromLabel: PageNameGenerator, 
                 postProcessPageName: postProcessPageName, 
                 postProcessLabel: postProcessLabel,
-                uriSuffix: `.${c.get('defaultFileExtension')}`,
-                description_then_file: c.get("pipedWikiLinksSyntax") == "desc|file",
-                separator: c.get("pipedWikiLinksSeparator")
+                uriSuffix: `.${NoteWorkspace.defaultFileExtension()}`,
+                description_then_file: NoteWorkspace.pipedWikiLinksSyntax() == "desc|file",
+                separator: NoteWorkspace.pipedWikiLinksSeparator(),
             }));
     }
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,60 @@ import { getRefAt, RefType } from './Ref';
 // import { debug } from 'util';
 // import { create } from 'domain';
 
+let c = vscode.workspace.getConfiguration("vscodeMarkdownNotes");
+
+// Function that returns a filename based on the given wikilink.
+// Initially uses filesForWikiLinkRefFromCache() to try and find a matching file.
+// If this fails, it will attempt to make a (relative) link based on the label given.
+function PageNameGenerator(label: string) {
+    console.debug(label);
+    const ref = {
+        type: RefType.WikiLink,
+        word: label,
+        hasExtension: false,
+        range: undefined
+    }
+    const results = MarkdownDefinitionProvider.filesForWikiLinkRefFromCache(ref, null);
+
+    label = label.replace(/\.[^\.\\\/]+$/, '');
+
+    // Either use the first result of the cache, or in the case that it's empty use the label to create a path
+    let path: string = (results.length != 0) ? results[0].path : NoteWorkspace.noteFileNameFromTitle(label);
+    
+    return path;
+}
+
+function postProcessPageName(pageName: string) {
+    pageName = pageName.trim();
+    pageName = pageName.replace(/\.[^\.\\\/]+$/, '');
+
+    return pageName;
+
+}
+  
+function postProcessLabel(label: string) {
+	label = label.trim();
+	
+	// Remove filename extension
+	label = label.replace(/\.[^/.]+$/, "");
+    
+    
+    label = label.split(`${c.get('slugifyCharacter')}`).join(" ");
+    if (c.get('showFileExtensionInPreview')) {
+        label += `.${c.get('defaultFileExtension')}`;
+    }
+
+    switch (c.get('previewlabelstyling')) {
+        case "[[label]]":
+            return `[[${label}]]`;
+        case "[label]":
+            return `[${label}]`;
+        case "label":
+            return label;
+    }
+    ;
+}
+
 export function activate(context: vscode.ExtensionContext) {
   // console.debug('vscode-markdown-notes.activate');
   const ds = NoteWorkspace.DOCUMENT_SELECTOR;
@@ -62,4 +116,21 @@ export function activate(context: vscode.ExtensionContext) {
   const treeView = vscode.window.createTreeView('vscodeMarkdownNotesBacklinks', {
     treeDataProvider: backlinksTreeDataProvider,
   });
+
+  // See: https://code.visualstudio.com/api/extension-guides/markdown-extension
+  // For more information on how this works.
+  return {
+    extendMarkdownIt(md: any) {
+        return md.use(
+            
+            require('@thomaskoppelaar/markdown-it-wikilinks')({ 
+                generatePageNameFromLabel: PageNameGenerator, 
+                postProcessPageName: postProcessPageName, 
+                postProcessLabel: postProcessLabel,
+                uriSuffix: `.${c.get('defaultFileExtension')}`,
+                description_then_file: c.get("pipedWikiLinksSyntax") == "desc|file",
+                separator: c.get("pipedWikiLinksSeparator")
+            }));
+    }
+    };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { MarkdownFileCompletionItemProvider } from './MarkdownFileCompletionItem
 import { NoteWorkspace } from './NoteWorkspace';
 import { NoteParser } from './NoteParser';
 import { getRefAt, RefType } from './Ref';
-import { PageNameGenerator, postProcessPageName, postProcessLabel } from './MarkdownRenderingPlugin';
+import { PageNameGenerator, postProcessPageName, postProcessLabel, pluginSettings } from './MarkdownRenderingPlugin';
 // import { debug } from 'util';
 // import { create } from 'domain';
 
@@ -69,15 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
   return {
     extendMarkdownIt(md: any) {
         return md.use(
-            
-            require('@thomaskoppelaar/markdown-it-wikilinks')({ 
-                generatePageNameFromLabel: PageNameGenerator, 
-                postProcessPageName: postProcessPageName, 
-                postProcessLabel: postProcessLabel,
-                uriSuffix: `.${NoteWorkspace.defaultFileExtension()}`,
-                description_then_file: NoteWorkspace.pipedWikiLinksSyntax() == "desc|file",
-                separator: NoteWorkspace.pipedWikiLinksSeparator(),
-            }));
-    }
+            pluginSettings()
+        )}
     };
 }


### PR DESCRIPTION
I've created a very simple way of caching (aka: just storing the result whenever we call the function) the notefiles.
This gets used by the renderer in order to either:
1. Use the (first) found link from the cache
2. Create a new (relative) link from the given wikilink.

This is all very cruddy and could definitely use improvement, but it works.