### PR TITLE
Ak files for wiki link ref from cache sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.0.17](https://github.com/kortina/vscode-markdown-notes/releases/edit/v0.0.17) (2020-08-23)
+
+Add `CompletionItem.documentation` to provide more details about completion options.
+
+**Enhancements:**
+
+- Set `CompletionItem.documentation` to the file contents, giving more detail to disambiguate between long / similar filenames. Closes #38. Tx @ahazxm
+  - Add `vscodeMarkdownNotes.compileSuggestionDetails` setting, which determines whether to render the markdown in the `CompletionItem.documentation`
+    - `true`: ![true](https://user-images.githubusercontent.com/24939578/90867513-13994e80-e3c8-11ea-9bb3-a98767796a2d.png)
+    - `false`: ![false](https://user-images.githubusercontent.com/24939578/90867523-16943f00-e3c8-11ea-86e8-29b7bd0cc0b7.png)
+
+**Diff:**
+
+https://github.com/kortina/vscode-markdown-notes/compare/fa011bb64c363a05231a043f39f800e7497617a9..271cf75cc2311a120eabd08f060270f927c0e401
+
 ## [v0.0.16](https://github.com/kortina/vscode-markdown-notes/releases/edit/v0.0.16) (2020-08-21)
 
 **Enhancements:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v0.0.16](https://github.com/kortina/vscode-markdown-notes/releases/edit/v0.0.16) (2020-08-21)
+
+**Enhancements:**
+
+- add setting `vscodeMarkdownNotes.newNoteDirectory`, can be set to:
+  - `SAME_AS_ACTIVE_NOTE`
+  - `WORKSPACE_ROOT`
+  - or `subdirectory/path` in workspace root
+- resolves #74
+
+**Diff:**
+
+https://github.com/kortina/vscode-markdown-notes/compare/808af92c40676ab2a9ae1d1de3611a930c6c5818..fa011bb64c363a05231a043f39f800e7497617a9
+
 ## [v0.0.15](https://github.com/kortina/vscode-markdown-notes/releases/edit/v0.0.15) (2020-08-18)
 
 **Fixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
   - or `subdirectory/path` in workspace root
 - resolves #74
 
+An example workspace config you might want to use to manage `_posts` on a jekyll blog:
+
+```jsonc
+{
+  "vscodeMarkdownNotes.newNoteDirectory": "_posts",
+  "vscodeMarkdownNotes.newNoteTemplate": "---\nlayout: post\ntitle: '${noteName}'\nauthor: kortina\n---\n\n"
+}
+```
+
 **Diff:**
 
 https://github.com/kortina/vscode-markdown-notes/compare/808af92c40676ab2a9ae1d1de3611a930c6c5818..fa011bb64c363a05231a043f39f800e7497617a9

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       {
         "command": "vscodeMarkdownNotes.newNote",
         "title": "Markdown Notes: New Note"
+      },
+      {
+        "command": "vscodeMarkdownNotes.notesForWikiLink",
+        "title": "Given some wiki-link text (from between double-brackets) such as \"my-note\" or \"my-note.md\" return a Note[] (typically of length 1) where the note filename is a match for the wiki-link text."
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-markdown-notes",
   "displayName": "Markdown Notes",
   "description": "Navigate notes with [[wiki-links]], backlinks, and #tags (like Bear, Roam, etc). Automatically create notes from new inline [[wiki-links]]. Use Peek Definition to preview linked notes.",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publisher": "kortina",
   "repository": {
     "url": "https://github.com/kortina/vscode-markdown-notes.git",
@@ -103,7 +103,7 @@
         "vscodeMarkdownNotes.compileSuggestionDetails": {
           "type": "boolean",
           "default": false,
-          "description": "Specifies whether to compile the markdown content for details when showing suggestion details"
+          "description": "Set `true` to compile the markdown content when showing suggestion documentation for a CompletionItem. Defaults `false`."
         },
         "vscodeMarkdownNotes.allowPipedWikiLinks": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-markdown-notes",
   "displayName": "Markdown Notes",
   "description": "Navigate notes with [[wiki-links]], backlinks, and #tags (like Bear, Roam, etc). Automatically create notes from new inline [[wiki-links]]. Use Peek Definition to preview linked notes.",
-  "version": "0.0.17",
+  "version": "0.0.19",
   "publisher": "kortina",
   "repository": {
     "url": "https://github.com/kortina/vscode-markdown-notes.git",

--- a/src/API.ts
+++ b/src/API.ts
@@ -5,7 +5,7 @@ import { NoteWorkspace } from './NoteWorkspace';
 import { refFromWikiLinkText } from './Ref';
 
 // This class serves as the public interface to commands that this extension exposes.
-class API {
+export class API {
   // Use vscode.window.showInputBox
   // to prompt user for a new note name
   // and create it upon entry.
@@ -21,6 +21,9 @@ class API {
   //   fsPath: string; // filesystem path to the Note
   //   data: string; // text contents of the Note
   // };
+  //
+  // example:
+  // let notes = await vscode.commands.executeCommand('vscodeMarkdownNotes.notesForWikiLink', 'demo');
   static async notesForWikiLink(
     wikiLinkText: string,
     relativeToDocument: vscode.TextDocument | undefined | null

--- a/src/API.ts
+++ b/src/API.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+import { MarkdownDefinitionProvider } from './MarkdownDefinitionProvider';
+import { Note, NoteParser } from './NoteParser';
+import { NoteWorkspace } from './NoteWorkspace';
+import { refFromWikiLinkText } from './Ref';
+
+// This class serves as the public interface to commands that this extension exposes.
+class API {
+  // Use vscode.window.showInputBox
+  // to prompt user for a new note name
+  // and create it upon entry.
+  static newNote(context: vscode.ExtensionContext) {
+    return NoteWorkspace.newNote(context);
+  }
+
+  // Given some wiki-link text (from between double-brackets) such as "my-note" or "my-note.md"
+  // return a Note[] (typically of length 1)
+  // where the note filename is a match for the wiki-link text.
+  // and
+  // type Note = {
+  //   fsPath: string; // filesystem path to the Note
+  //   data: string; // text contents of the Note
+  // };
+  static async notesForWikiLink(
+    wikiLinkText: string,
+    relativeToDocument: vscode.TextDocument | undefined | null
+  ): Promise<Note[]> {
+    const ref = refFromWikiLinkText(wikiLinkText);
+    let files: Array<vscode.Uri> = await MarkdownDefinitionProvider.filesForWikiLinkRef(
+      ref,
+      relativeToDocument
+    );
+    let notes: Note[] = (files || [])
+      .filter((f) => f.fsPath)
+      .map((f) => NoteParser.noteFromFsPath(f.fsPath))
+      // see: https://stackoverflow.com/questions/43010737/way-to-tell-typescript-compiler-array-prototype-filter-removes-certain-types-fro
+      .filter((n): n is Note => {
+        return n != undefined;
+      });
+    return Promise.resolve(notes);
+  }
+}

--- a/src/API.ts
+++ b/src/API.ts
@@ -32,7 +32,7 @@ export class API {
     let files: Array<vscode.Uri> = await MarkdownDefinitionProvider.filesForWikiLinkRef(
       ref,
       relativeToDocument
-    );
+    ); // TODO: async
     let notes: Note[] = (files || [])
       .filter((f) => f.fsPath)
       .map((f) => NoteParser.noteFromFsPath(f.fsPath))

--- a/src/MarkdownDefinitionProvider.ts
+++ b/src/MarkdownDefinitionProvider.ts
@@ -46,6 +46,26 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
     ref: Ref,
     relativeToDocument: vscode.TextDocument | undefined | null
   ): Promise<Array<vscode.Uri>> {
+    let files: Array<vscode.Uri> = await NoteWorkspace.noteFiles();
+    return this._filesForWikiLinkRefAndNoteFiles(ref, relativeToDocument, files);
+  }
+
+  static filesForWikiLinkRefFromCache(
+    ref: Ref,
+    relativeToDocument: vscode.TextDocument | undefined | null
+  ) {
+    let files = NoteWorkspace.noteFilesFromCache(); // TODO: cache results from NoteWorkspace.noteFiles()
+    return this._filesForWikiLinkRefAndNoteFiles(ref, relativeToDocument, files);
+  }
+
+  // Brunt of the logic for either
+  // filesForWikiLinkRef
+  // or, filesForWikiLinkRefFromCache
+  static _filesForWikiLinkRefAndNoteFiles(
+    ref: Ref,
+    relativeToDocument: vscode.TextDocument | undefined | null,
+    noteFiles: Array<vscode.Uri>
+  ): Array<vscode.Uri> {
     let files: Array<vscode.Uri> = [];
     // ref.word might be either:
     // a basename for a unique file in the workspace
@@ -56,7 +76,7 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
     // However, only check for basenames in the entire project if:
     if (NoteWorkspace.useUniqueFilenames()) {
       // there should be exactly 1 file with name = ref.word
-      files = (await NoteWorkspace.noteFiles()).filter((f) => {
+      files = noteFiles.filter((f) => {
         return NoteWorkspace.noteNamesFuzzyMatch(f.fsPath, ref.word);
       });
     }

--- a/src/MarkdownRenderingPlugin.ts
+++ b/src/MarkdownRenderingPlugin.ts
@@ -1,63 +1,63 @@
 import { MarkdownDefinitionProvider } from './MarkdownDefinitionProvider';
 import { NoteWorkspace } from './NoteWorkspace';
-import { RefType } from './Ref';
+import { RefType, refFromWikiLinkText } from './Ref';
 
 // See also: https://github.com/tomleesm/markdown-it-wikilinks
 // Function that returns a filename based on the given wikilink.
 // Initially uses filesForWikiLinkRefFromCache() to try and find a matching file.
 // If this fails, it will attempt to make a (relative) link based on the label given.
 export function PageNameGenerator(label: string) {
-    const ref = {
-        type: RefType.WikiLink,
-        word: label,
-        hasExtension: false,
-        range: undefined
-    }
-    const results = MarkdownDefinitionProvider.filesForWikiLinkRefFromCache(ref, null);
+  const ref = refFromWikiLinkText(label);
+  const results = MarkdownDefinitionProvider.filesForWikiLinkRefFromCache(ref, null);
 
-    label = NoteWorkspace.stripExtension(label);
+  // NB: it is kind of weird that we need to strip the extension here
+  // to make noteFileNameFromTitle work,
+  // but then noteFileNameFromTitle adds back the default extension...
+  // Prolly will lead to some bugs, and maybe we should add an optional
+  // extension argument to noteFileNameFromTitle...
+  label = NoteWorkspace.stripExtension(label);
 
-    // Either use the first result of the cache, or in the case that it's empty use the label to create a path
-    let path: string = (results.length != 0) ? results[0].path : NoteWorkspace.noteFileNameFromTitle(label);
-    
-    return path;
+  // Either use the first result of the cache, or in the case that it's empty use the label to create a path
+  let path: string =
+    results.length != 0 ? results[0].path : NoteWorkspace.noteFileNameFromTitle(label);
+
+  return path;
 }
 
 // Transformation that only gets applied to the page name (ex: the "test-file.md" part of [[test-file.md | Description goes here]]).
 export function postProcessPageName(pageName: string) {
-    return NoteWorkspace.stripExtension(pageName);
+  return NoteWorkspace.stripExtension(pageName);
 }
 
 // Transformation that only gets applied to the link label (ex: the " Description goes here" part of [[test-file.md | Description goes here]])
 export function postProcessLabel(label: string) {
-    // Trim whitespaces
-    label = label.trim();
-    
-    // De-slugify label into whitespaces
-    label = label.split(NoteWorkspace.slugifyChar()).join(" ");
+  // Trim whitespaces
+  label = label.trim();
 
-    if (NoteWorkspace.previewShowFileExtension()) {
-        label += `.${NoteWorkspace.defaultFileExtension()}`;
-    }
+  // De-slugify label into white-spaces
+  label = label.split(NoteWorkspace.slugifyChar()).join(' ');
 
-    switch (NoteWorkspace.previewLabelStyling()) {
-        case "[[label]]":
-            return `[[${label}]]`;
-        case "[label]":
-            return `[${label}]`;
-        case "label":
-            return label;
-    }
-    ;
+  if (NoteWorkspace.previewShowFileExtension()) {
+    label += `.${NoteWorkspace.defaultFileExtension()}`;
+  }
+
+  switch (NoteWorkspace.previewLabelStyling()) {
+    case '[[label]]':
+      return `[[${label}]]`;
+    case '[label]':
+      return `[${label}]`;
+    case 'label':
+      return label;
+  }
 }
 
 export function pluginSettings(): any {
-    return require('@thomaskoppelaar/markdown-it-wikilinks')({ 
-        generatePageNameFromLabel: PageNameGenerator, 
-        postProcessPageName: postProcessPageName, 
-        postProcessLabel: postProcessLabel,
-        uriSuffix: `.${NoteWorkspace.defaultFileExtension()}`,
-        description_then_file: NoteWorkspace.pipedWikiLinksSyntax() == "desc|file",
-        separator: NoteWorkspace.pipedWikiLinksSeparator(),
-    });
+  return require('@thomaskoppelaar/markdown-it-wikilinks')({
+    generatePageNameFromLabel: PageNameGenerator,
+    postProcessPageName: postProcessPageName,
+    postProcessLabel: postProcessLabel,
+    uriSuffix: `.${NoteWorkspace.defaultFileExtension()}`,
+    description_then_file: NoteWorkspace.pipedWikiLinksSyntax() == 'desc|file',
+    separator: NoteWorkspace.pipedWikiLinksSeparator(),
+  });
 }

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -29,9 +29,9 @@ enum PipedWikiLinksSyntax {
 }
 
 enum PreviewLabelStyling {
-    brackets = "[[label]]",
-    bracket = "[label]",
-    none = "label"
+  brackets = '[[label]]',
+  bracket = '[label]',
+  none = 'label',
 }
 
 type Config = {
@@ -154,11 +154,11 @@ export class NoteWorkspace {
   }
 
   static previewLabelStyling(): string {
-      return this.cfg().previewLabelStyling;
+    return this.cfg().previewLabelStyling;
   }
 
   static previewShowFileExtension(): boolean {
-      return this.cfg().previewShowFileExtension;
+    return this.cfg().previewShowFileExtension;
   }
 
   static rxTagNoAnchors(): RegExp {

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -87,8 +87,7 @@ export function getRefAt(document: vscode.TextDocument, position: vscode.Positio
       return {
         type: RefType.WikiLink,
         word: ref, // .replace(/^\[+/, ''),
-        // TODO: parameterize extensions. Add $ to end?
-        hasExtension: !!ref.match(/\.(md|markdown)/i),
+        hasExtension: refHasExtension(ref),
         range: r, // range,
       };
     }
@@ -98,7 +97,7 @@ export function getRefAt(document: vscode.TextDocument, position: vscode.Positio
 }
 
 export const refHasExtension = (word: string): boolean => {
-  return !!word.match(/\.(md|markdown)/i);
+  return !!word.match(NoteWorkspace.rxFileExtensions());
 };
 
 export const refFromWikiLinkText = (wikiLinkText: string): Ref => {

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -96,3 +96,16 @@ export function getRefAt(document: vscode.TextDocument, position: vscode.Positio
 
   return NULL_REF;
 }
+
+export const refHasExtension = (word: string): boolean => {
+  return !!word.match(/\.(md|markdown)/i);
+};
+
+export const refFromWikiLinkText = (wikiLinkText: string): Ref => {
+  return {
+    type: RefType.WikiLink,
+    word: wikiLinkText,
+    hasExtension: refHasExtension(wikiLinkText),
+    range: undefined,
+  };
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { API } from './API';
 import { BacklinksTreeDataProvider } from './BacklinksTreeDataProvider';
 import { MarkdownDefinitionProvider } from './MarkdownDefinitionProvider';
 import { MarkdownReferenceProvider } from './MarkdownReferenceProvider';
@@ -45,6 +46,11 @@ export function activate(context: vscode.ExtensionContext) {
     NoteWorkspace.newNote
   );
   context.subscriptions.push(newNoteDisposable);
+  let d = vscode.commands.registerCommand(
+    'vscodeMarkdownNotes.notesForWikiLink',
+    API.notesForWikiLink
+  );
+  context.subscriptions.push(d);
 
   // parse the tags from every file in the workspace
   NoteParser.hydrateCache();


### PR DESCRIPTION
- add `API.ts` with a 'beta' public API (subject to change), [one example function](https://github.com/kortina/vscode-markdown-notes/pull/87/files#diff-e24351dfe2836d766dcaa5d2873075ebR26):
```ts
let notes = await vscode.commands.executeCommand(
  'vscodeMarkdownNotes.notesForWikiLink', 
  'demo'
);
```
- add a sync version of `filesForWikiLinkRef`, `filesForWikiLinkRefFromCache`
- merge #86 from @thomaskoppelaar, with...
- `markdownItPlugins` rendering of wiki-links
- add setting: `vscodeMarkdownNotes.previewShowFileExtension` - Specifies whether or not to show the linked file's extension in the preview
- add setting: `vscodeMarkdownNotes.previewLabelStyling` - Changes how the link to a file should be shown, either with or without brackets
