### PR TITLE
fix bdd parser so it also handles typescript

### DIFF
--- a/jest-focused.sh
+++ b/jest-focused.sh
@@ -7,7 +7,8 @@
 #
 set -e
 # location of script that will parse out the test function given a filepath and line
-test_at_line_js="out/test-at-line.js"
+wd=`pwd`
+test_at_line_js="$wd/out/test-at-line.js"
 
 # arg $1 is the test filename
 # replace "/./"" with "/" (artifact of vscode-run-in-terminal starting relative path with a "./")
@@ -24,8 +25,7 @@ npm run compile
 
 # if given file + line number, parse out the test name to run and pass in as a focused test run
 if echo "$1" | grep -q ":[0-9]\+$" ; then
-    cmd="node $(pwd)/ $testloc"
-    bdd_description=$(node $(pwd)/$test_at_line_js $1)
+    bdd_description=$(node $test_at_line_js $1)
     bdd_size=${#bdd_description}
     if [ $bdd_size -eq 0 ]; then
         echo "Not in a describe block, nothing to run!"

--- a/src/test-at-line.ts
+++ b/src/test-at-line.ts
@@ -10,6 +10,8 @@
 type FixMe = any;
 
 let babylon = require('babylon');
+babylon = require('@babel/parser');
+
 let fs = require('fs');
 
 let bddFunctionNames = ['describe', 'context', 'it', 'test'];
@@ -47,9 +49,19 @@ function constructJasmineSpecDescriptionAtLine(
 }
 
 function main(file: FixMe, lineNumber: FixMe) {
+  // Cannot combine flow and typescript plugins.
+  // Default to js:
+  let plugins = ['flow', 'jsx', 'objectRestSpread'];
+  let presets: Array<string> = [];
+  // typescript version:
+  if (file.match(/\.ts$/)) {
+    plugins = ['typescript', 'objectRestSpread'];
+    presets = ['@babel/preset-typescript'];
+  }
   let ast = babylon.parse(fs.readFileSync(file, 'utf8'), {
     sourceType: 'module',
-    plugins: ['jsx', 'flow', 'objectRestSpread'],
+    presets: presets,
+    plugins: plugins,
   });
   let descriptionParts = constructJasmineSpecDescriptionAtLine(ast.program.body, lineNumber, []);
   let description = descriptionParts.join(' ');


### PR DESCRIPTION
The jest line runner (invoked with `<leader>rl` in vscode vim) was broken -- originally it only worked with js, but using this way incorrectly got the bdd description because the line number was for the source typescript file. There was a naive fix awhile back that just pointed `test-at-line.js` at the `ts` file, but babel parser was failing on that.

This PR 
- updates the babel parser to handle typescript
- points `test-at-line.js` test file to get the bdd description
- invokes jest on the compiled `out` js versions of the ts test files
