### PR TITLE
Adds command to create new note from selected text

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,8 +120,8 @@
         },
         "vscodeMarkdownNotes.newNoteFromSelectionReplacementTemplate": {
           "type": "string",
-          "default": "${wikiLink}",
-          "description": "Template for generated links to notes created from selections. Available tokens: ${wikiLink}."
+          "default": "[[${wikiLink}]]",
+          "description": "Template for generated links to notes created from selections. Available tokens: ${wikiLink}, ${noteName}."
         },
         "vscodeMarkdownNotes.compileSuggestionDetails": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
         "title": "Markdown Notes: New Note"
       },
       {
+        "command": "vscodeMarkdownNotes.newNoteFromSelection",
+        "title": "Markdown Notes: New Note From Selection"
+      },
+      {
         "command": "vscodeMarkdownNotes.notesForWikiLink",
         "title": "Given some wiki-link text (from between double-brackets) such as \"my-note\" or \"my-note.md\" return a Note[] (typically of length 1) where the note filename is a match for the wiki-link text."
       }
@@ -113,6 +117,11 @@
           "type": "string",
           "default": "# ${noteName}\n\n",
           "description": "Template for auto-created note files. Available tokens: ${noteName}, ${timestamp}. Timestamp is inserted in ISO format, i.e. 2020-07-09T05:29:00.541Z."
+        },
+        "vscodeMarkdownNotes.newNoteFromSelectionReplacementTemplate": {
+          "type": "string",
+          "default": "${wikiLink}",
+          "description": "Template for generated links to notes created from selections. Available tokens: ${wikiLink}."
         },
         "vscodeMarkdownNotes.compileSuggestionDetails": {
           "type": "boolean",

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -85,7 +85,7 @@ export class NoteWorkspace {
     slugifyMethod: SlugifyMethod.classic,
     workspaceFilenameConvention: WorkspaceFilenameConvention.uniqueFilenames,
     newNoteTemplate: '# ${noteName}\n\n',
-    newNoteFromSelectionReplacementTemplate: '${wikiLink}',
+    newNoteFromSelectionReplacementTemplate: '[[${wikiLink}]]',
     triggerSuggestOnReplacement: true,
     allowPipedWikiLinks: false,
     pipedWikiLinksSyntax: PipedWikiLinksSyntax.fileDesc,
@@ -458,7 +458,7 @@ export class NoteWorkspace {
                 edit.replace(
                   originEditor.document.uri, 
                   originSelectionRange, 
-                  NoteWorkspace.selectionReplacementContent(`[[${wikiLink}]]`)
+                  NoteWorkspace.selectionReplacementContent(wikiLink, noteName)
                 );
 
                 vscode.workspace.applyEdit(edit);
@@ -547,10 +547,11 @@ export class NoteWorkspace {
     return contents;
   }
 
-  static selectionReplacementContent(wikiLink: string) {
+  static selectionReplacementContent(wikiLink: string, noteName: string) {
     const template = NoteWorkspace.newNoteFromSelectionReplacementTemplate();
     const contents = template
-      .replace(/\$\{wikiLink\}/g, wikiLink);
+      .replace(/\$\{wikiLink\}/g, wikiLink)
+      .replace(/\$\{noteName\}/g, noteName);
 
     return contents;
   }

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -50,6 +50,7 @@ type Config = {
   slugifyMethod: SlugifyMethod;
   workspaceFilenameConvention: WorkspaceFilenameConvention;
   newNoteTemplate: string;
+  newNoteFromSelectionReplacementTemplate: string;
   compileSuggestionDetails: boolean;
   triggerSuggestOnReplacement: boolean;
   allowPipedWikiLinks: boolean;
@@ -84,6 +85,7 @@ export class NoteWorkspace {
     slugifyMethod: SlugifyMethod.classic,
     workspaceFilenameConvention: WorkspaceFilenameConvention.uniqueFilenames,
     newNoteTemplate: '# ${noteName}\n\n',
+    newNoteFromSelectionReplacementTemplate: '${wikiLink}',
     triggerSuggestOnReplacement: true,
     allowPipedWikiLinks: false,
     pipedWikiLinksSyntax: PipedWikiLinksSyntax.fileDesc,
@@ -116,6 +118,7 @@ export class NoteWorkspace {
         'workspaceFilenameConvention'
       ) as WorkspaceFilenameConvention,
       newNoteTemplate: c.get('newNoteTemplate') as string,
+      newNoteFromSelectionReplacementTemplate: c.get('newNoteFromSelectionReplacementTemplate') as string,
       compileSuggestionDetails: c.get('compileSuggestionDetails') as boolean,
       triggerSuggestOnReplacement: c.get('triggerSuggestOnReplacement') as boolean,
       allowPipedWikiLinks: c.get('allowPipedWikiLinks') as boolean,
@@ -141,6 +144,10 @@ export class NoteWorkspace {
 
   static newNoteTemplate(): string {
     return this.cfg().newNoteTemplate;
+  }
+
+  static newNoteFromSelectionReplacementTemplate(): string {
+    return this.cfg().newNoteFromSelectionReplacementTemplate;
   }
 
   static triggerSuggestOnReplacement() {
@@ -342,13 +349,17 @@ export class NoteWorkspace {
     return t.match(this.rxFileExtensions()) ? t : `${t}.${this.defaultFileExtension()}`;
   }
 
-  static newNote(context: vscode.ExtensionContext) {
-    // console.debug('newNote');
-    const inputBoxPromise = vscode.window.showInputBox({
+  static showNewNoteInputBox() {
+    return vscode.window.showInputBox({
       prompt:
         "Enter a 'Title Case Name' to create `title-case-name.md` with '# Title Case Name' at the top.",
       value: '',
     });
+  }
+
+  static newNote(context: vscode.ExtensionContext) {
+    // console.debug('newNote');
+    const inputBoxPromise = NoteWorkspace.showNewNoteInputBox();
 
     inputBoxPromise.then(
       (noteName) => {
@@ -365,14 +376,92 @@ export class NoteWorkspace {
             preview: false,
           })
           .then(() => {
-            // if we created a new file, hop to line #3
+            // if we created a new file, place the selection at the end of the last line of the template
             if (!fileAlreadyExists) {
               let editor = vscode.window.activeTextEditor;
               if (editor) {
-                const lineNumber = 3;
-                let range = editor.document.lineAt(lineNumber - 1).range;
-                editor.selection = new vscode.Selection(range.start, range.end);
+                const lineNumber = editor.document.lineCount;
+                const range = editor.document.lineAt(lineNumber - 1).range;
+                editor.selection = new vscode.Selection(range.end, range.end);
                 editor.revealRange(range);
+              }
+            }
+          });
+      },
+      (err) => {
+        vscode.window.showErrorMessage('Error creating new note.');
+      }
+    );
+  }
+
+  static newNoteFromSelection(context: vscode.ExtensionContext) {
+    const originEditor = vscode.window.activeTextEditor;
+
+    if (!originEditor) {
+      // console.debug('Abort: no active editor');
+      return;
+    }
+    const { selection } = originEditor;
+    const noteContents = originEditor.document.getText(selection);
+    const originSelectionRange = new vscode.Range(selection.start, selection.end);
+
+    if (noteContents === '') {
+      vscode.window.showErrorMessage('Error creating note from selection: selection is empty.');
+      return;
+    }
+    
+    // console.debug('newNote');
+    const inputBoxPromise = NoteWorkspace.showNewNoteInputBox();
+
+    inputBoxPromise.then(
+      (noteName) => {
+        if (noteName == null || !noteName || noteName.replace(/\s+/g, '') == '') {
+          // console.debug('Abort: noteName was empty.');
+          return false;
+        }
+        const { filepath, fileAlreadyExists } = NoteWorkspace.createNewNoteFile(noteName);
+        const destinationUri = vscode.Uri.file(filepath);
+
+        // open the file:
+        vscode.window
+          .showTextDocument(destinationUri, {
+            preserveFocus: false,
+            preview: false,
+          })
+          .then(() => {
+            if (!fileAlreadyExists) {
+              const destinationEditor = vscode.window.activeTextEditor;
+              if (destinationEditor) {
+                // Place the selection at the end of the last line of the template
+                const lineNumber = destinationEditor.document.lineCount;
+                const range = destinationEditor.document.lineAt(lineNumber - 1).range;
+                destinationEditor.selection = new vscode.Selection(range.end, range.end);
+                destinationEditor.revealRange(range);
+
+                // Insert the selected content in to the new file
+                destinationEditor.edit(edit => {
+                  if (destinationEditor) {
+                    console.log(range);
+                    if (range.start.character === range.end.character) {
+                      edit.insert(destinationEditor.selection.end, noteContents);
+                    } else {
+                      // If the last line is not empty, insert the note contents on a new line
+                      edit.insert(destinationEditor.selection.end, '\n\n' + noteContents);
+                    }
+                  }
+                });
+
+                // Replace the selected content in the origin file with a wiki-link to the new file
+                const edit = new vscode.WorkspaceEdit();
+                const wikiLink = NoteWorkspace.wikiLinkCompletionForConvention(destinationUri, originEditor.document);
+
+                edit.replace(
+                  originEditor.document.uri, 
+                  originSelectionRange, 
+                  NoteWorkspace.selectionReplacementContent(`[[${wikiLink}]]`)
+                );
+
+                vscode.workspace.applyEdit(edit);
               }
             }
           });
@@ -455,6 +544,14 @@ export class NoteWorkspace {
       .replace(/\$\{noteName\}/g, noteName)
       .replace(/\$\{timestamp\}/g, t)
       .replace(/\$\{date\}/g, d);
+    return contents;
+  }
+
+  static selectionReplacementContent(wikiLink: string) {
+    const template = NoteWorkspace.newNoteFromSelectionReplacementTemplate();
+    const contents = template
+      .replace(/\$\{wikiLink\}/g, wikiLink);
+
     return contents;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,11 @@ export function activate(context: vscode.ExtensionContext) {
     NoteWorkspace.newNote
   );
   context.subscriptions.push(newNoteDisposable);
+  let newNoteFromSelectionDisposable = vscode.commands.registerCommand(
+    'vscodeMarkdownNotes.newNoteFromSelection',
+    NoteWorkspace.newNoteFromSelection
+  );
+  context.subscriptions.push(newNoteFromSelectionDisposable);
   let d = vscode.commands.registerCommand(
     'vscodeMarkdownNotes.notesForWikiLink',
     API.notesForWikiLink


### PR DESCRIPTION
This PR implements #70 

![note-from-selection](https://user-images.githubusercontent.com/2694747/94321112-93748480-ff43-11ea-8ec2-c252ba3ed3fa.gif)

It adds a new command `vscodeMarkdownNotes.newNoteFromSelection` that will clip selected text into a new note, and replace the text in the original note with a wiki link.

It also adds a template string for the output of the wiki link. This is to allow for users to modify the replacement text (eg. I prefer `(See: [[my-new-file]])` vs. just `[[my-new-file]]`).

Please let me know if you have any feedback or would like any modifications!