### PR TITLE
Adds option to disable lowercasing of file names

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
           "default": "# ${noteName}\n\n",
           "description": "Template for auto-created note files. Available tokens: ${noteName}, ${timestamp}. Timestamp is inserted in ISO format, i.e. 2020-07-09T05:29:00.541Z."
         },
+        "vscodeMarkdownNotes.lowercaseNewNoteFilenames": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, new note file names will be converted to lowercase. Otherwise, the case will be preserved. Eg: my-new-note.md vs. My-New-Note.md"
+        },
         "vscodeMarkdownNotes.compileSuggestionDetails": {
           "type": "boolean",
           "default": false,

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -50,6 +50,7 @@ type Config = {
   slugifyMethod: SlugifyMethod;
   workspaceFilenameConvention: WorkspaceFilenameConvention;
   newNoteTemplate: string;
+  lowercaseNewNoteFilenames: boolean;
   compileSuggestionDetails: boolean;
   triggerSuggestOnReplacement: boolean;
   allowPipedWikiLinks: boolean;
@@ -84,6 +85,7 @@ export class NoteWorkspace {
     slugifyMethod: SlugifyMethod.classic,
     workspaceFilenameConvention: WorkspaceFilenameConvention.uniqueFilenames,
     newNoteTemplate: '# ${noteName}\n\n',
+    lowercaseNewNoteFilenames: true,
     triggerSuggestOnReplacement: true,
     allowPipedWikiLinks: false,
     pipedWikiLinksSyntax: PipedWikiLinksSyntax.fileDesc,
@@ -116,6 +118,7 @@ export class NoteWorkspace {
         'workspaceFilenameConvention'
       ) as WorkspaceFilenameConvention,
       newNoteTemplate: c.get('newNoteTemplate') as string,
+      lowercaseNewNoteFilenames: c.get('lowercaseNewNoteFilenames') as boolean,
       compileSuggestionDetails: c.get('compileSuggestionDetails') as boolean,
       triggerSuggestOnReplacement: c.get('triggerSuggestOnReplacement') as boolean,
       allowPipedWikiLinks: c.get('allowPipedWikiLinks') as boolean,
@@ -141,6 +144,10 @@ export class NoteWorkspace {
 
   static newNoteTemplate(): string {
     return this.cfg().newNoteTemplate;
+  }
+
+  static lowercaseNewNoteFilenames(): boolean {
+    return this.cfg().lowercaseNewNoteFilenames;
   }
 
   static triggerSuggestOnReplacement() {
@@ -311,9 +318,12 @@ export class NoteWorkspace {
   }
 
   static cleanTitle(title: string): string {
-    return title
-      .toLowerCase() // lower
-      .replace(/[-_－＿ ]*$/g, ''); // removing trailing slug chars
+    const caseAdjustedTitle = this.lowercaseNewNoteFilenames() ? 
+      title.toLowerCase() : 
+      title;
+
+    // removing trailing slug chars
+    return caseAdjustedTitle.replace(/[-_－＿ ]*$/g, ''); 
   }
 
   static slugifyClassic(title: string): string {

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -38,25 +38,35 @@ describe('NoteWorkspace.slug', () => {
   });
 
   test('noteFileNameFromTitle', () => {
-    setConfig({ slugifyCharacter: NoteWorkspace.SLUGIFY_NONE });
+    setConfig({ slugifyCharacter: NoteWorkspace.SLUGIFY_NONE, lowercaseNewNoteFilenames: true });
     expect(NoteWorkspace.noteFileNameFromTitle('Some Title')).toEqual('some title.md');
     expect(NoteWorkspace.noteFileNameFromTitle('Some Title ')).toEqual('some title.md');
+    setConfig({ slugifyCharacter: NoteWorkspace.SLUGIFY_NONE, lowercaseNewNoteFilenames: false });
+    expect(NoteWorkspace.noteFileNameFromTitle('Some Title')).toEqual('Some Title.md');
 
-    setConfig({ slugifyCharacter: '-' });
+    setConfig({ slugifyCharacter: '-', lowercaseNewNoteFilenames: true });
     expect(NoteWorkspace.noteFileNameFromTitle('Some " Title ')).toEqual('some-title.md');
     expect(NoteWorkspace.noteFileNameFromTitle('Šömè Țítlê')).toEqual('šömè-țítlê.md');
     expect(NoteWorkspace.noteFileNameFromTitle('題目')).toEqual('題目.md');
     expect(NoteWorkspace.noteFileNameFromTitle('Some \r \n Title')).toEqual('some-title.md');
+    setConfig({ slugifyCharacter: '-', lowercaseNewNoteFilenames: false });
+    expect(NoteWorkspace.noteFileNameFromTitle('Some " Title ')).toEqual('Some-Title.md');
 
-    setConfig({ slugifyCharacter: '_' });
+    setConfig({ slugifyCharacter: '_', lowercaseNewNoteFilenames: true });
     expect(NoteWorkspace.noteFileNameFromTitle('Some   Title ')).toEqual('some_title.md');
+    setConfig({ slugifyCharacter: '_', lowercaseNewNoteFilenames: false });
+    expect(NoteWorkspace.noteFileNameFromTitle('Some   Title ')).toEqual('Some_Title.md');
 
-    setConfig({ slugifyCharacter: '－' });
+    setConfig({ slugifyCharacter: '－', lowercaseNewNoteFilenames: true });
     expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ')).toEqual(
       'ｓｏｍｅ－ｔｉｔｌｅ.md'
     );
     expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ ')).toEqual(
       'ｓｏｍｅ－ｔｉｔｌｅ.md'
+    );
+    setConfig({ slugifyCharacter: '－', lowercaseNewNoteFilenames: false });
+    expect(NoteWorkspace.noteFileNameFromTitle('Ｓｏｍｅ　Ｔｉｔｌｅ ')).toEqual(
+      'Ｓｏｍｅ－Ｔｉｔｌｅ.md'
     );
   });
 });


### PR DESCRIPTION
This PR implements #59 by adding an option `lowercaseNewNoteFilenames`, and using this option to conditionally lowercase file names in `cleanTitle`
