### PR TITLE
Add collapse all button to backlinks view

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,6 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.window.onDidChangeActiveTextEditor(() => backlinksTreeDataProvider.reload());
   const treeView = vscode.window.createTreeView('vscodeMarkdownNotesBacklinks', {
     treeDataProvider: backlinksTreeDataProvider,
+    showCollapseAll: true
   });
 
   // See: https://code.visualstudio.com/api/extension-guides/markdown-extension


### PR DESCRIPTION
This just adds a collapse all button to the backlinks view. For me, there are some notes that I link all over the place and I want to be able to get an overview of where it's linked without seeing every single line.