### PR TITLE
Markdown Hyperlinks Showing up in the backlinks panel

### DIFF
--- a/src/BacklinksTreeDataProvider.ts
+++ b/src/BacklinksTreeDataProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { NoteParser } from './NoteParser';
+import { RefType } from './Ref';
 
 type FileWithLocations = {
   file: string;
@@ -95,7 +96,12 @@ export class BacklinksTreeDataProvider implements vscode.TreeDataProvider<Backli
     // Parse the workspace into list of FilesWithLocations
     // Return 1 collapsible element per file
     if (!element) {
-      return NoteParser.searchBacklinksFor(activeFilename).then((locations) => {
+      return Promise.all(
+      [ NoteParser.searchBacklinksFor(activeFilename, RefType.WikiLink), 
+        NoteParser.searchBacklinksFor(activeFilename, RefType.Hyperlink)])
+      .then((arr) => {
+
+        let locations: vscode.Location[]  = arr[0].concat(arr[1]);
         let filesWithLocations = BacklinksTreeDataProvider.locationListToTree(locations);
         return filesWithLocations.map((fwl) => BacklinkItem.fromFileWithLocations(fwl));
       });

--- a/src/MarkdownDefinitionProvider.ts
+++ b/src/MarkdownDefinitionProvider.ts
@@ -23,7 +23,7 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
     token: vscode.CancellationToken
   ) {
     const ref = getRefAt(document, position);
-    if (ref.type != RefType.WikiLink) {
+    if (ref.type != RefType.WikiLink && ref.type != RefType.Hyperlink) {
       return [];
     }
 
@@ -96,7 +96,7 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
 
   static createMissingNote = (ref: Ref): string | undefined => {
     // don't create new files if ref is a Tag
-    if (ref.type != RefType.WikiLink) {
+    if (ref.type != RefType.WikiLink && ref.type != RefType.Hyperlink) {
       return;
     }
     if (!NoteWorkspace.createNoteOnGoToDefinitionWhenMissing()) {

--- a/src/MarkdownDefinitionProvider.ts
+++ b/src/MarkdownDefinitionProvider.ts
@@ -96,7 +96,7 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
 
   static createMissingNote = (ref: Ref): string | undefined => {
     // don't create new files if ref is a Tag
-    if (ref.type != RefType.WikiLink && ref.type != RefType.Hyperlink) {
+    if (ref.type != RefType.WikiLink) {
       return;
     }
     if (!NoteWorkspace.createNoteOnGoToDefinitionWhenMissing()) {

--- a/src/MarkdownFileCompletionItemProvider.ts
+++ b/src/MarkdownFileCompletionItemProvider.ts
@@ -38,6 +38,7 @@ export class MarkdownFileCompletionItemProvider implements vscode.CompletionItem
           }
           return item;
         });
+      case RefType.Hyperlink:
       case RefType.WikiLink:
         return (await NoteWorkspace.noteFiles()).map((f) => {
           let kind = vscode.CompletionItemKind.File;

--- a/src/MarkdownFileCompletionItemProvider.ts
+++ b/src/MarkdownFileCompletionItemProvider.ts
@@ -39,6 +39,15 @@ export class MarkdownFileCompletionItemProvider implements vscode.CompletionItem
           return item;
         });
       case RefType.Hyperlink:
+        return (await NoteWorkspace.noteFiles()).map((f) => {
+            let kind = vscode.CompletionItemKind.File;
+            let label = NoteWorkspace.wikiLinkCompletionForConvention(f, document);
+            let item = new MarkdownFileCompletionItem(label, kind, f.fsPath);
+            if (ref && ref.range) {
+              item.range = ref.range;
+            }
+            return item;
+          });
       case RefType.WikiLink:
         return (await NoteWorkspace.noteFiles()).map((f) => {
           let kind = vscode.CompletionItemKind.File;

--- a/src/MarkdownFileCompletionItemProvider.ts
+++ b/src/MarkdownFileCompletionItemProvider.ts
@@ -38,16 +38,6 @@ export class MarkdownFileCompletionItemProvider implements vscode.CompletionItem
           }
           return item;
         });
-      case RefType.Hyperlink:
-        return (await NoteWorkspace.noteFiles()).map((f) => {
-            let kind = vscode.CompletionItemKind.File;
-            let label = NoteWorkspace.wikiLinkCompletionForConvention(f, document);
-            let item = new MarkdownFileCompletionItem(label, kind, f.fsPath);
-            if (ref && ref.range) {
-              item.range = ref.range;
-            }
-            return item;
-          });
       case RefType.WikiLink:
         return (await NoteWorkspace.noteFiles()).map((f) => {
           let kind = vscode.CompletionItemKind.File;

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -75,6 +75,7 @@ export class NoteWorkspace {
   static _rxWikiLink = '\\[\\[[^sep\\]]+(sep[^sep\\]]+)?\\]\\]'; // [[wiki-link-regex(|with potential pipe)?]] Note: "sep" will be replaced with pipedWikiLinksSeparator on compile
   static _rxTitle = '(?<=^( {0,3}#[^\\S\\r\\n]+)).+';
   static _rxMarkdownWordPattern = '([_\\p{L}#\\.\\/\\\\]+)'; // had to add [".", "/", "\"] to get relative path completion working and ["#"] to get tag completion working
+  static _rxMarkdownHyperlink = '\\[[^\\[\\]]*\\]\\((?!https?)[^\\(\\)\\[\\] ]+\\)';
   static _rxFileExtensions = '\\.(md|markdown|mdx|fountain|txt)$';
   static SLUGIFY_NONE = 'NONE';
   static NEW_NOTE_SAME_AS_ACTIVE_NOTE = 'SAME_AS_ACTIVE_NOTE';
@@ -213,6 +214,10 @@ export class NoteWorkspace {
     return new RegExp(this._rxFileExtensions, 'i');
   }
 
+  static rxMarkdownHyperlink(): RegExp {
+      return new RegExp(this._rxMarkdownHyperlink, 'gi');
+  }
+
   static wikiLinkCompletionForConvention(
     uri: vscode.Uri,
     fromDocument: vscode.TextDocument
@@ -297,6 +302,7 @@ export class NoteWorkspace {
   static normalizeNoteNameForFuzzyMatchText(noteName: string): string {
     // remove the brackets:
     let n = noteName.replace(/[\[\]]/g, '');
+    
     // remove the potential description:
     n = this.cleanPipedWikiLink(n);
     // remove the extension:
@@ -306,6 +312,23 @@ export class NoteWorkspace {
     return n;
   }
 
+
+  // compare a hyperlink to a filename for a fuzzy match.
+  // `left` is the ref word, `right` is the file name
+  static noteNamesFuzzyMatchHyperlinks(left: string, right: string): boolean {
+
+      // strip markdown link syntax; remove the [description]
+      left = left.replace(/\[[^\[\]]*\]/g,'');
+      // and the () surrounding the link
+      left = left.replace(/\(|\)/g, '');
+
+     
+      return (
+        this.normalizeNoteNameForFuzzyMatch(left).toLowerCase() ==
+        this.normalizeNoteNameForFuzzyMatchText(right).toLowerCase()
+      );
+
+  }
   // Compare 2 wiki-links for a fuzzy match.
   // In general, we expect
   // `left` to be fsPath

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -75,7 +75,7 @@ export class NoteWorkspace {
   static _rxWikiLink = '\\[\\[[^sep\\]]+(sep[^sep\\]]+)?\\]\\]'; // [[wiki-link-regex(|with potential pipe)?]] Note: "sep" will be replaced with pipedWikiLinksSeparator on compile
   static _rxTitle = '(?<=^( {0,3}#[^\\S\\r\\n]+)).+';
   static _rxMarkdownWordPattern = '([_\\p{L}#\\.\\/\\\\]+)'; // had to add [".", "/", "\"] to get relative path completion working and ["#"] to get tag completion working
-  static _rxMarkdownHyperlink = '\\[[^\\[\\]]*\\]\\((?!https?)[^\\(\\)\\[\\] ]+\\)';
+  static _rxMarkdownHyperlink = '\\[[^\\[\\]]*\\]\\((?!https?)[^\\(\\)\\[\\] ]+\\)'; // [description](hyperlink-to-file.md), ensuring the link doesn't start with http(s)
   static _rxFileExtensions = '\\.(md|markdown|mdx|fountain|txt)$';
   static SLUGIFY_NONE = 'NONE';
   static NEW_NOTE_SAME_AS_ACTIVE_NOTE = 'SAME_AS_ACTIVE_NOTE';

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -135,7 +135,7 @@ export function getEmptyRefAt(document: vscode.TextDocument, position: vscode.Po
   let searchRange = new vscode.Range(s, position);
   let precedingChars = document.getText(searchRange);
 
-  if (precedingChars == '[[' || precedingChars == '](') {
+  if (precedingChars == '[[') {
     return {
       type: RefType.WikiLink,
       word: '', // just use empty string

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -105,9 +105,13 @@ export function getRefAt(document: vscode.TextDocument, position: vscode.Positio
   range = document.getWordRangeAtPosition(position, regex);
   if (range) {
       ref = document.getText(range);
+      // remove the [description] from the hyperlink
       ref = ref.replace(/\[[^\[\]]*\]/, '');
+
+      // remove the () surrounding the link
       ref = ref.replace(/\(|\)/g,'');
-      console.log(ref);
+
+      // e.g. [desc](link.md) gets turned into link.md
 
       return {
           type: RefType.Hyperlink,

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -14,6 +14,7 @@ export enum RefType {
   Null, // 0
   WikiLink, // 1
   Tag, // 2
+  Hyperlink, // 3
 }
 
 export interface Ref {
@@ -97,6 +98,23 @@ export function getRefAt(document: vscode.TextDocument, position: vscode.Positio
         range: r, // range,
       };
     }
+  }
+
+
+  regex = NoteWorkspace.rxMarkdownHyperlink();
+  range = document.getWordRangeAtPosition(position, regex);
+  if (range) {
+      ref = document.getText(range);
+      ref = ref.replace(/\[[^\[\]]*\]/, '');
+      ref = ref.replace(/\(|\)/g,'');
+      console.log(ref);
+
+      return {
+          type: RefType.Hyperlink,
+          word: ref,
+          hasExtension: refHasExtension(ref),
+          range: range,
+      };
   }
 
   return NULL_REF;

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -135,7 +135,7 @@ export function getEmptyRefAt(document: vscode.TextDocument, position: vscode.Po
   let searchRange = new vscode.Range(s, position);
   let precedingChars = document.getText(searchRange);
 
-  if (precedingChars == '[[') {
+  if (precedingChars == '[[' || precedingChars == '](') {
     return {
       type: RefType.WikiLink,
       word: '', // just use empty string

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -169,6 +169,20 @@ describe('NoteWorkspace.rx', () => {
     // the character before the match needs to be a space or start of line:
     expect('https://something.com/?q=v#com').not.toMatch(rx);
   });
+
+  test('rxMarkdownHyperlink', () => {
+    let rx = NoteWorkspace.rxMarkdownHyperlink();
+    // "regular" use of link:
+    expect(('Some link to [test](test.md).'.match(rx)|| [])[0]).toEqual('[test](test.md)');
+    // no description:
+    expect(('Some link to [](test.md).'.match(rx) || [])[0]).toEqual('[](test.md)');
+
+    // empty link:
+    expect('Some link to nowhere []().').not.toMatch(rx);
+
+    // link to a website:
+    expect('Some link to [google](https://google.com).').not.toMatch(rx);
+  });
 });
 
 let document = `line0 word1
@@ -177,8 +191,10 @@ line1 word1 word2
 ^ tags at line2 chars 15-19 and 21-32
 [[test.md]] <- link at line4, chars 0-11
 [[demo.md]] <- link at line5, chars 0-11
-#tag word <- line 5, chars 0-3
-# [[]] [[`; // line 6, empty refs
+#tag word <- line 6, chars 0-3
+# [[]] [[ <- line 7, empty refs
+[](test-hyperlink.md) <- link at line8, chars 0-11
+[]() [](`; // line 9, empty refs
 
 describe('Note', () => {
   test('Note._rawRangesForWord', () => {
@@ -214,6 +230,16 @@ describe('Note', () => {
     ranges = Note.fromData(document)._rawRangesForWord(w);
     expect(ranges).toMatchObject([
       { start: { line: 2, character: 20 }, end: { line: 2, character: 32 } },
+    ]);
+    w = {
+        word: 'test-hyperlink.md',
+        hasExtension: true,
+        type: RefType.Hyperlink,
+        range: undefined,
+    };
+    ranges = Note.fromData(document)._rawRangesForWord(w);
+    expect(ranges).toMatchObject([
+        { start: {line: 8, character: 0}, end: {line: 8, character: 21} },
     ]);
   });
 

--- a/test/test.md
+++ b/test/test.md
@@ -8,5 +8,6 @@
 - [[sub.md]] - exists in sub directory
 - [[extension test mirror]]
 - [[extension-test-mirror.md]]
+- [](test) - hyperlink (should show up in the backlinks panel)
 
 #tag #another_tag

--- a/test/test.md
+++ b/test/test.md
@@ -8,6 +8,6 @@
 - [[sub.md]] - exists in sub directory
 - [[extension test mirror]]
 - [[extension-test-mirror.md]]
-- [](test) - hyperlink (should show up in the backlinks panel)
+- [](test) - hyperlink (should show up in the backlinks panel) - Note: autocompletion or file creation is not handled by this extension.
 
 #tag #another_tag


### PR DESCRIPTION
Markdown hyperlinks now get parsed and shown in the backlinks panel.
Note that this does not make hyperlinks first-class citizens of this extension: They will not be getting autocomplete suggestions from this extension, nor will you be able to click on them to create the file on a missing definition.


Closes: #46