### PR TITLE
Support workspace-relative path to bibtex file

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
         "vscodeMarkdownNotes.bibtexFilePath": {
           "type": "string",
           "default": "",
-          "description": "Path to a global BibTex file that will provide autocompletion for @bibtex-citations"
+          "description": "Absolute or current workspace relative path to a BibTeX file that will provide autocompletion for @bibtex-citations."
         }
       }
     },

--- a/test/.vscode/settings.json
+++ b/test/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "vscodeMarkdownNotes.bibtexFilePath": "library.bib",
+}


### PR DESCRIPTION
Add support for absolute and current workspace-relative path when specifying the bibtex file, as discussed [here](https://github.com/kortina/vscode-markdown-notes/pull/124#issuecomment-784640089).

This solution also a workaround for the fact that vscode settings cannot be currently specified as for instance `${workspaceFolder}/path/to/file`, see more detailed discussion [here](https://github.com/Microsoft/vscode/issues/2809)