### PR TITLE
Fix nested tag syntax highlighting

### DIFF
--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -70,7 +70,7 @@ export class NoteWorkspace {
   // This will allow us to potentially expose these as settings.
   // Note for the future: \p{L} is used instead of \w , in order to match to all possible letters
   // rather than just those from the latin alphabet.
-  static _rxTag = '(?<= |,|^)#[\\p{L}\\-_]+'; // match # followed by a letter character
+  static _rxTag = '(?<= |,|^)#[\\p{L}\\-_/]+'; // match # followed by a letter character
   static _rxBeginTag = '(?<= |,|^)#'; // match # preceded by a space, comma, or newline, regardless of whether it is followed by a letter character
   static _rxWikiLink = '\\[\\[[^sep\\]]+(sep[^sep\\]]+)?\\]\\]'; // [[wiki-link-regex(|with potential pipe)?]] Note: "sep" will be replaced with pipedWikiLinksSeparator on compile
   static _rxTitle = '(?<=^( {0,3}#[^\\S\\r\\n]+)).+';

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -156,11 +156,14 @@ describe('NoteWorkspace.rx', () => {
     expect(('http://something/ something #draft/tag/id middle.'.match(rx) || [])[0]).toEqual('#draft/tag/id');
     expect(('http://something/ something #draft /tag/id middle.'.match(rx) || [])[0]).toEqual('#draft');
     expect(('http://something/ something end #draft'.match(rx) || [])[0]).toEqual('#draft');
+    expect(('http://something/ something end #draft/id'.match(rx) || [])[0]).toEqual('#draft/id');
     expect(('http://something/ #draft.'.match(rx) || [])[0]).toEqual('#draft');
     // preceded by comma:
     expect((',#draft,'.match(rx) || [])[0]).toEqual('#draft');
+    expect((',#draft/id,'.match(rx) || [])[0]).toEqual('#draft/id');
     // start of line:
     expect(('#draft start'.match(rx) || [])[0]).toEqual('#draft');
+    expect(('#draft/id start'.match(rx) || [])[0]).toEqual('#draft/id');
     // the character before the match needs to be a space or start of line:
     expect('[site](http://something/#com).').not.toMatch(rx);
     expect('[site](http://something/#com/id).').not.toMatch(rx);

--- a/src/test/jest/extension.test.ts
+++ b/src/test/jest/extension.test.ts
@@ -152,6 +152,9 @@ describe('NoteWorkspace.rx', () => {
     let rx = NoteWorkspace.rxTag();
     // preceded by space:
     expect(('http://something/ something #draft middle.'.match(rx) || [])[0]).toEqual('#draft');
+    expect(('http://something/ something #draft/tag middle.'.match(rx) || [])[0]).toEqual('#draft/tag');
+    expect(('http://something/ something #draft/tag/id middle.'.match(rx) || [])[0]).toEqual('#draft/tag/id');
+    expect(('http://something/ something #draft /tag/id middle.'.match(rx) || [])[0]).toEqual('#draft');
     expect(('http://something/ something end #draft'.match(rx) || [])[0]).toEqual('#draft');
     expect(('http://something/ #draft.'.match(rx) || [])[0]).toEqual('#draft');
     // preceded by comma:
@@ -160,7 +163,9 @@ describe('NoteWorkspace.rx', () => {
     expect(('#draft start'.match(rx) || [])[0]).toEqual('#draft');
     // the character before the match needs to be a space or start of line:
     expect('[site](http://something/#com).').not.toMatch(rx);
+    expect('[site](http://something/#com/id).').not.toMatch(rx);
     expect('[site](https://something.com/?q=v#com).').not.toMatch(rx);
+    expect('[site](https://something.com/?q=v#com/id).').not.toMatch(rx);
   });
 
   test('rxBeginTag', () => {

--- a/syntaxes/notes.tmLanguage.json
+++ b/syntaxes/notes.tmLanguage.json
@@ -40,7 +40,7 @@
       }
     },
     {
-      "match": "(\\#)([\\w\\p{L}\\-\\_]+)",
+      "match": "(\\#)([\\w\\p{L}\\-\\_/]+)",
       "name": "text.markdown.notes.tag",
       "captures": {
         "1": {


### PR DESCRIPTION
Fix highlights for nested tags, as described in issue https://github.com/kortina/vscode-markdown-notes/issues/157.