### PR TITLE
Use `vscode` instead of `fs` to create new files

### DIFF
--- a/src/MarkdownDefinitionProvider.ts
+++ b/src/MarkdownDefinitionProvider.ts
@@ -36,7 +36,7 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
 
     // else, create the file
     if (files.length == 0) {
-      const path = MarkdownDefinitionProvider.createMissingNote(ref);
+      const path = await MarkdownDefinitionProvider.createMissingNote(ref);
       if (path !== undefined) {
         files.push(vscode.Uri.file(path));
       }
@@ -98,7 +98,7 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
     return files;
   }
 
-  static createMissingNote = (ref: Ref): string | undefined => {
+  static  createMissingNote = async (ref: Ref): Promise<string | undefined> => {
     // don't create new files if ref is a Tag
     if (ref.type != RefType.WikiLink) {
       return;
@@ -115,7 +115,7 @@ export class MarkdownDefinitionProvider implements vscode.DefinitionProvider {
         return;
       }
       const title = NoteWorkspace.stripExtension(ref.word);
-      const { filepath, fileAlreadyExists } = NoteWorkspace.createNewNoteFile(title);
+      const { filepath, fileAlreadyExists } = await NoteWorkspace.createNewNoteFile(title);
       return filepath;
     }
   };

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -394,12 +394,12 @@ export class NoteWorkspace {
     const inputBoxPromise = NoteWorkspace.showNewNoteInputBox();
 
     inputBoxPromise.then(
-      (noteName) => {
+      async (noteName) => {
         if (noteName == null || !noteName || noteName.replace(/\s+/g, '') == '') {
           // console.debug('Abort: noteName was empty.');
           return false;
         }
-        const { filepath, fileAlreadyExists } = NoteWorkspace.createNewNoteFile(noteName);
+        const { filepath, fileAlreadyExists } = await NoteWorkspace.createNewNoteFile(noteName);
 
         // open the file:
         vscode.window
@@ -446,12 +446,12 @@ export class NoteWorkspace {
     const inputBoxPromise = NoteWorkspace.showNewNoteInputBox();
 
     inputBoxPromise.then(
-      (noteName) => {
+      async (noteName) => {
         if (noteName == null || !noteName || noteName.replace(/\s+/g, '') == '') {
           // console.debug('Abort: noteName was empty.');
           return false;
         }
-        const { filepath, fileAlreadyExists } = NoteWorkspace.createNewNoteFile(noteName);
+        const { filepath, fileAlreadyExists } = await NoteWorkspace.createNewNoteFile(noteName);
         const destinationUri = vscode.Uri.file(filepath);
 
         // open the file:
@@ -506,7 +506,7 @@ export class NoteWorkspace {
     );
   }
 
-  static createNewNoteFile(noteTitle: string) {
+  static async createNewNoteFile(noteTitle: string) {
     let workspacePath = '';
     if (vscode.workspace.workspaceFolders) {
       workspacePath = vscode.workspace.workspaceFolders[0].uri.fsPath.toString();
@@ -563,9 +563,8 @@ export class NoteWorkspace {
       const edit = new vscode.WorkspaceEdit();
       const fileUri = vscode.Uri.file(filepath);
       edit.createFile(fileUri);
-      vscode.workspace.applyEdit(edit).then(() => 
-        vscode.workspace.fs.writeFile(fileUri, new TextEncoder().encode(contents))
-      );
+      await vscode.workspace.applyEdit(edit);
+      await vscode.workspace.fs.writeFile(fileUri, new TextEncoder().encode(contents));
     }
 
     return {

--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { basename, dirname, isAbsolute, join, normalize, relative } from 'path';
-import { existsSync, writeFileSync } from 'fs';
+import { existsSync } from 'fs';
+import { TextEncoder } from 'util';
 import findNonIgnoredFiles from './findNonIgnoredFiles';
 const GithubSlugger = require('github-slugger');
 const SLUGGER = new GithubSlugger();
@@ -559,7 +560,12 @@ export class NoteWorkspace {
     } else {
       // create the file if it does not exist
       const contents = NoteWorkspace.newNoteContent(noteTitle);
-      writeFileSync(filepath, contents);
+      const edit = new vscode.WorkspaceEdit();
+      const fileUri = vscode.Uri.file(filepath);
+      edit.createFile(fileUri);
+      vscode.workspace.applyEdit(edit).then(() => 
+        vscode.workspace.fs.writeFile(fileUri, new TextEncoder().encode(contents))
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary

Use `vscode.WorkspaceEdit.createFile` instead of `fs.writeFileSync` to create new files.

## Why

Other extensions on vscode might want to know when files are created in the workspace. The best way to do this, is by listening for a `FileCreateEvent` with [`vscode.workspace.onDidCreateFiles`](https://code.visualstudio.com/api/references/vscode-api#workspace). This event is not fired if `vscode.workspace.fs` or a foreign program or script creates the file.

## Choices made

Since `vscode.workspace.fs.writeFile` will also create a file if none is found, we wait for the `vscode.workspace.applyEdit` to finish to execute it.