### PR TITLE
Don't show error when file already exists

### DIFF
--- a/src/NoteWorkspace.ts
+++ b/src/NoteWorkspace.ts
@@ -552,11 +552,7 @@ export class NoteWorkspace {
     const filepath = join(noteDirectory, filename);
 
     const fileAlreadyExists = existsSync(filepath);
-    if (fileAlreadyExists) {
-      vscode.window.showWarningMessage(
-        `Error creating note, file at path already exists: ${filepath}`
-      );
-    } else {
+    if (!fileAlreadyExists) {
       // create the file if it does not exist
       const contents = NoteWorkspace.newNoteContent(noteTitle);
       writeFileSync(filepath, contents);


### PR DESCRIPTION
Thank you for the work in this extension! I use it everyday :-)

This addresses one of my concerns in https://github.com/kortina/vscode-markdown-notes/issues/162. I don't think a file already existing should be considered an error. Either way, the file is opened.
