### PR TITLE
Make wiki-links work in VSCode's Markdown preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "vscode-markdown-notes",
       "version": "0.0.25",
       "dependencies": {
-        "@thomaskoppelaar/markdown-it-wikilinks": "^1.3.0",
         "github-slugger": "^1.3.0"
       },
       "devDependencies": {
@@ -2532,16 +2531,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/@thomaskoppelaar/markdown-it-wikilinks": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@thomaskoppelaar/markdown-it-wikilinks/-/markdown-it-wikilinks-1.3.0.tgz",
-      "integrity": "sha512-yJTwX9dxwnjw7Kxi6hyP4gY3fLu6EMoTQRWSSGA3iCBZGCRhwCmYs4KIguFSZfgYag329MELnGguuGIy/lNRFQ==",
-      "dependencies": {
-        "extend": "^3.0.0",
-        "markdown-it-regexp": "^0.4.0",
-        "sanitize-filename": "^1.6.1"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -4883,7 +4872,8 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
@@ -9569,11 +9559,6 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
-    "node_modules/markdown-it-regexp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz",
-      "integrity": "sha1-1k1xPuzsVc5M/esyF1DswJniwtw="
-    },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -12130,14 +12115,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-      "dependencies": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -13084,14 +13061,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "dependencies": {
-        "utf8-byte-length": "^1.0.1"
-      }
-    },
     "node_modules/ts-jest": {
       "version": "26.4.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
@@ -13685,11 +13654,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/utf8-byte-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -16230,16 +16194,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@thomaskoppelaar/markdown-it-wikilinks": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@thomaskoppelaar/markdown-it-wikilinks/-/markdown-it-wikilinks-1.3.0.tgz",
-      "integrity": "sha512-yJTwX9dxwnjw7Kxi6hyP4gY3fLu6EMoTQRWSSGA3iCBZGCRhwCmYs4KIguFSZfgYag329MELnGguuGIy/lNRFQ==",
-      "requires": {
-        "extend": "^3.0.0",
-        "markdown-it-regexp": "^0.4.0",
-        "sanitize-filename": "^1.6.1"
-      }
-    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -18070,7 +18024,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -21732,11 +21687,6 @@
         }
       }
     },
-    "markdown-it-regexp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz",
-      "integrity": "sha1-1k1xPuzsVc5M/esyF1DswJniwtw="
-    },
     "mdast-util-from-markdown": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
@@ -23577,14 +23527,6 @@
         }
       }
     },
-    "sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-      "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -24340,14 +24282,6 @@
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
-    "truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "requires": {
-        "utf8-byte-length": "^1.0.1"
-      }
-    },
     "ts-jest": {
       "version": "26.4.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
@@ -24811,11 +24745,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "utf8-byte-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "vscode-markdown-notes",
       "version": "0.0.25",
       "dependencies": {
-        "github-slugger": "^1.3.0"
+        "github-slugger": "^1.3.0",
+        "markdown-it-regexp": "^0.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.10.1",
@@ -9558,6 +9559,11 @@
       "bin": {
         "markdown-it": "bin/markdown-it.js"
       }
+    },
+    "node_modules/markdown-it-regexp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz",
+      "integrity": "sha512-0XQmr46K/rMKnI93Y3CLXsHj4jIioRETTAiVnJnjrZCEkGaDOmUxTbZj/aZ17G5NlRcVpWBYjqpwSlQ9lj+Kxw=="
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
@@ -21686,6 +21692,11 @@
           "dev": true
         }
       }
+    },
+    "markdown-it-regexp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz",
+      "integrity": "sha512-0XQmr46K/rMKnI93Y3CLXsHj4jIioRETTAiVnJnjrZCEkGaDOmUxTbZj/aZ17G5NlRcVpWBYjqpwSlQ9lj+Kxw=="
     },
     "mdast-util-from-markdown": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,6 @@
     "watch": "tsc -watch -p ./"
   },
   "dependencies": {
-    "@thomaskoppelaar/markdown-it-wikilinks": "^1.3.0",
     "github-slugger": "^1.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -206,7 +206,8 @@
     "watch": "tsc -watch -p ./"
   },
   "dependencies": {
-    "github-slugger": "^1.3.0"
+    "github-slugger": "^1.3.0",
+    "markdown-it-regexp": "^0.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.1",

--- a/src/MarkdownRenderingPlugin.ts
+++ b/src/MarkdownRenderingPlugin.ts
@@ -56,6 +56,8 @@ function postProcessLabel(label: string) {
 }
 
 export function pluginSettings(): any {
+  // The code below was adapted from @thomaskoppelaar/markdown-it-wikilinks (375ce4650c),
+  // which was a forked version of @jsepia/markdown-it-wikilinks.
   return require("markdown-it-regexp")(
     new RegExp("\\[\\[([^sep\\]]+)(sep[^sep\\]]+)?\\]\\]".replace(/sep/g, NoteWorkspace.pipedWikiLinksSeparator())),
     (match: any, utils: any) => {
@@ -93,7 +95,8 @@ export function pluginSettings(): any {
       href = utils.escape(href);
 
       htmlAttrs.push(`href="${href}"`);
-      htmlAttrs.push(`data-href="${href}"`);
+      // The following line is necessary for the wiki-links to work on VSCode's Markdown preview
+      htmlAttrs.push(`data-href="${href}"`); 
       htmlAttrsString = htmlAttrs.join(' ');
       
       return `<a ${htmlAttrsString}>${label}</a>`;

--- a/src/MarkdownRenderingPlugin.ts
+++ b/src/MarkdownRenderingPlugin.ts
@@ -1,6 +1,8 @@
 import { MarkdownDefinitionProvider } from './MarkdownDefinitionProvider';
 import { NoteWorkspace } from './NoteWorkspace';
 import { RefType, refFromWikiLinkText } from './Ref';
+import { workspace } from 'vscode';
+
 
 // See also: https://github.com/tomleesm/markdown-it-wikilinks
 // Function that returns a filename based on the given wikilink.
@@ -18,8 +20,9 @@ export function PageNameGenerator(label: string) {
   label = NoteWorkspace.stripExtension(label);
 
   // Either use the first result of the cache, or in the case that it's empty use the label to create a path
-  let path: string =
-    results.length != 0 ? results[0].path : NoteWorkspace.noteFileNameFromTitle(label);
+  let path = results.length != 0 ?
+    workspace.asRelativePath(results[0].path, false) :
+    NoteWorkspace.noteFileNameFromTitle(label);
 
   return path;
 }


### PR DESCRIPTION
Thank you for the excellent extension! I like Markdown Notes so much that I recommended it to my colleagues, but I also want to see this improved a bit.

## Summary

This PR addresses #6 and makes wiki-links work in Markdown preview.

## What's changed

* Supply href with paths relative to the workspace root
* Set data-href as well as href for A-tags

The first change was necessary because 

1. VSCode's Uri.path starts with "/" and represents a full path in the file system, but
1. href starting with "/" is interpreted as a path relative to the document root, which in this case is the workspace root.

Therefore, to get the desired behavior, we need to fill href with a path relative to the document or the workspace folder.

Regarding the second change, it seems necessary for links in the preview window to work as expected.

## Implementation details

Regarding the second change, I chose to copy, paste and modify the code from markdown-it-wikilinks, which is a markdown-it plugin that renders wiki-links. A cleaner approach would be to use a version of markdown-it-wikilinks that sets the data-href attribute (e.g. @shdwcat/markdown-it-wikilinks, see also https://github.com/thomaskoppelaar/markdown-it-wikilinks/pull/1). I made this choice because I just wanted to have it work as quickly as possible without worrying about any side effects caused by changing dependent packages.

## Limitations

A rendered wiki-link would be incorrect if `"vscodeMarkdownNotes.workspaceFilenameConvention": "relativePaths"` or the wiki-link itself is a relative path.